### PR TITLE
Fix emoji rendering and add system theme with terminal color reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ main.js
 .DS_Store
 Thumbs.db
 .claude/
+data.json
+shell-integration/

--- a/package.json
+++ b/package.json
@@ -18,8 +18,9 @@
     "typescript": "^5.8.0"
   },
   "dependencies": {
-    "@xterm/xterm": "^5.5.0",
     "@xterm/addon-fit": "^0.10.0",
-    "@xterm/addon-web-links": "^0.11.0"
+    "@xterm/addon-unicode11": "^0.8.0",
+    "@xterm/addon-web-links": "^0.11.0",
+    "@xterm/xterm": "^5.5.0"
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ export default class TerminalPlugin extends Plugin {
   settings: TerminalPluginSettings = DEFAULT_SETTINGS;
   binaryManager!: BinaryManager;
   private ribbonEl: HTMLElement | null = null;
+  private themeObserver: MutationObserver | null = null;
 
   async onload(): Promise<void> {
     await this.loadSettings();
@@ -65,9 +66,25 @@ export default class TerminalPlugin extends Plugin {
 
     // Settings tab
     this.addSettingTab(new TerminalSettingTab(this.app, this));
+
+    // Watch for Obsidian theme changes (dark/light toggle)
+    this.themeObserver = new MutationObserver((mutations) => {
+      for (const m of mutations) {
+        if (m.type === "attributes" && m.attributeName === "class") {
+          // Only re-theme when user chose "system" (auto-follow Obsidian)
+          if (this.settings.theme === "system") {
+            this.updateTerminalThemes();
+          }
+        }
+      }
+    });
+    this.themeObserver.observe(document.body, { attributes: true, attributeFilter: ["class"] });
   }
 
   onunload(): void {
+    this.themeObserver?.disconnect();
+    this.themeObserver = null;
+
     // Detach after a tick to avoid disrupting the settings modal
     setTimeout(() => {
       this.app.workspace.detachLeavesOfType(VIEW_TYPE_TERMINAL);
@@ -147,6 +164,15 @@ export default class TerminalPlugin extends Plugin {
       // tabHeaderInnerIconEl is undocumented but stable across Obsidian versions
       const iconEl = (leaf as WorkspaceLeaf & { tabHeaderInnerIconEl?: HTMLElement }).tabHeaderInnerIconEl;
       if (iconEl) setIcon(iconEl, safeName);
+    }
+  }
+
+  /** Re-apply the full theme to all terminal views (e.g. after Obsidian dark/light switch). */
+  updateTerminalThemes(): void {
+    const leaves = this.app.workspace.getLeavesOfType(VIEW_TYPE_TERMINAL);
+    for (const leaf of leaves) {
+      const view = leaf.view as TerminalView;
+      view.updateTheme();
     }
   }
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -23,7 +23,7 @@ export const DEFAULT_SETTINGS: TerminalPluginSettings = {
   shellPath: "",
   fontSize: 14,
   fontFamily: "Menlo, Monaco, 'Courier New', monospace",
-  theme: "obsidian-dark",
+  theme: "system",
   backgroundColor: "",
   cursorBlink: true,
   scrollback: 5000,
@@ -145,14 +145,17 @@ export class TerminalSettingTab extends PluginSettingTab {
 
     new Setting(containerEl)
       .setName("Theme")
+      .setDesc("\"System\" follows Obsidian\u2019s dark/light mode automatically")
       .addDropdown((dropdown) => {
         for (const name of THEME_NAMES) {
-          dropdown.addOption(name, name);
+          const label = name === "system" ? "System (follow Obsidian)" : name;
+          dropdown.addOption(name, label);
         }
         dropdown.setValue(this.plugin.settings.theme);
         dropdown.onChange(async (value) => {
           this.plugin.settings.theme = value;
           await this.plugin.saveSettings();
+          this.plugin.updateTerminalThemes();
         });
       });
 

--- a/src/terminal-tab-manager.ts
+++ b/src/terminal-tab-manager.ts
@@ -2,6 +2,7 @@ import { Notice } from "obsidian";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
+import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { PtyManager } from "./pty-manager";
 import { getTheme } from "./themes";
 import type { TerminalPluginSettings } from "./settings";
@@ -160,14 +161,18 @@ export class TerminalTabManager {
       fontFamily: this.settings.fontFamily,
       cursorBlink: this.settings.cursorBlink,
       scrollback: this.settings.scrollback,
+      allowProposedApi: true,
       theme,
     });
 
     const fitAddon = new FitAddon();
     const webLinksAddon = new WebLinksAddon();
+    const unicode11Addon = new Unicode11Addon();
 
     terminal.loadAddon(fitAddon);
     terminal.loadAddon(webLinksAddon);
+    terminal.loadAddon(unicode11Addon);
+    terminal.unicode.activeVersion = "11";
     terminal.open(containerEl);
 
     // Intercept clipboard shortcuts — Obsidian captures them before xterm.js

--- a/src/terminal-tab-manager.ts
+++ b/src/terminal-tab-manager.ts
@@ -143,6 +143,14 @@ function sessionBackground(session: TerminalSession): string {
   return (session.terminal.options.theme?.background) || "#1e1e1e";
 }
 
+function resolveTerminalTheme(settings: TerminalPluginSettings) {
+  const theme = getTheme(settings.theme);
+  if (settings.backgroundColor) {
+    theme.background = settings.backgroundColor;
+  }
+  return theme;
+}
+
 /**
  * Register OSC 10/11 query handlers and Mode 2031 / CSI ?996n handlers
  * on a terminal session. Responses are written back to the PTY so the child
@@ -233,10 +241,7 @@ export class TerminalTabManager {
     const containerEl = this.terminalHostEl.createDiv({ cls: "terminal-session" });
 
     // Create xterm.js instance
-    const theme = getTheme(this.settings.theme);
-    if (this.settings.backgroundColor) {
-      theme.background = this.settings.backgroundColor;
-    }
+    const theme = resolveTerminalTheme(this.settings);
     const terminal = new Terminal({
       fontSize: this.settings.fontSize,
       fontFamily: this.settings.fontFamily,
@@ -528,10 +533,7 @@ export class TerminalTabManager {
   }
 
   updateBackgroundColor(): void {
-    const theme = getTheme(this.settings.theme);
-    if (this.settings.backgroundColor) {
-      theme.background = this.settings.backgroundColor;
-    }
+    const theme = resolveTerminalTheme(this.settings);
     for (const session of this.sessions) {
       session.terminal.options.theme = { ...session.terminal.options.theme, background: theme.background };
     }
@@ -539,10 +541,7 @@ export class TerminalTabManager {
 
   /** Re-apply the full theme to all sessions (used when Obsidian switches dark/light). */
   updateTheme(): void {
-    const theme = getTheme(this.settings.theme);
-    if (this.settings.backgroundColor) {
-      theme.background = this.settings.backgroundColor;
-    }
+    const theme = resolveTerminalTheme(this.settings);
     const isDark = isObsidianDark();
     for (const session of this.sessions) {
       session.terminal.options.theme = theme;

--- a/src/terminal-tab-manager.ts
+++ b/src/terminal-tab-manager.ts
@@ -4,10 +4,11 @@ import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { PtyManager } from "./pty-manager";
-import { getTheme } from "./themes";
+import { getTheme, isObsidianDark } from "./themes";
 import type { TerminalPluginSettings } from "./settings";
 import type { NotificationSound } from "./settings";
 import type { BinaryManager } from "./binary-manager";
+import type { IDisposable } from "@xterm/xterm";
 
 export const TAB_COLORS = [
   { name: "None", value: "" },
@@ -27,6 +28,10 @@ export interface TerminalSession {
   pty: PtyManager;
   containerEl: HTMLElement;
   color: string;
+  /** Whether this session has opted into Mode 2031 color-scheme-change notifications. */
+  mode2031: boolean;
+  /** Disposables for parser handlers (cleaned up on tab close). */
+  parserDisposables: IDisposable[];
 }
 
 let sessionCounter = 0;
@@ -108,6 +113,82 @@ function playNotificationSound(sound: NotificationSound, volume: number): void {
   } catch {
     // Audio not available — silently ignore
   }
+}
+
+// ---------------------------------------------------------------------------
+// Terminal color reporting helpers (OSC 10/11, Mode 2031)
+// ---------------------------------------------------------------------------
+
+const ESC = "\x1b";
+const BEL = "\x07";
+const ST = `${ESC}\\`;
+const HEX6_RE = /^#[0-9a-fA-F]{6}$/;
+
+/** Convert "#RRGGBB" hex to X11 "rgb:RRRR/GGGG/BBBB" (16-bit per component). */
+function hexToX11(hex: string): string {
+  if (!HEX6_RE.test(hex)) return "rgb:0000/0000/0000";
+  const r = hex.slice(1, 3);
+  const g = hex.slice(3, 5);
+  const b = hex.slice(5, 7);
+  return `rgb:${r}${r}/${g}${g}/${b}${b}`;
+}
+
+/** Get the effective foreground color for a session. */
+function sessionForeground(session: TerminalSession): string {
+  return (session.terminal.options.theme?.foreground) || "#d4d4d4";
+}
+
+/** Get the effective background color for a session. */
+function sessionBackground(session: TerminalSession): string {
+  return (session.terminal.options.theme?.background) || "#1e1e1e";
+}
+
+/**
+ * Register OSC 10/11 query handlers and Mode 2031 / CSI ?996n handlers
+ * on a terminal session. Responses are written back to the PTY so the child
+ * app reads them from stdin — matching real terminal behavior.
+ */
+function registerColorReporting(session: TerminalSession): void {
+  const { terminal, pty } = session;
+  const d: IDisposable[] = session.parserDisposables;
+
+  // --- OSC 10 ; ? — query default foreground color ---
+  d.push(terminal.parser.registerOscHandler(10, (data: string) => {
+    if (data !== "?") return false; // not a query, let default handler run
+    const color = hexToX11(sessionForeground(session));
+    pty.write(`${ESC}]10;${color}${BEL}`);
+    return true;
+  }));
+
+  // --- OSC 11 ; ? — query default background color ---
+  d.push(terminal.parser.registerOscHandler(11, (data: string) => {
+    if (data !== "?") return false;
+    const color = hexToX11(sessionBackground(session));
+    pty.write(`${ESC}]11;${color}${BEL}`);
+    return true;
+  }));
+
+  // --- CSI ? 996 n — one-shot dark/light mode query ---
+  d.push(terminal.parser.registerCsiHandler({ prefix: "?", final: "n" }, (params) => {
+    if (params[0] !== 996) return false;
+    const mode = isObsidianDark() ? 1 : 2; // 1 = dark, 2 = light
+    pty.write(`${ESC}[?997;${mode}n`);
+    return true;
+  }));
+
+  // --- CSI ? 2031 h — enable Mode 2031 (color-scheme-change notifications) ---
+  d.push(terminal.parser.registerCsiHandler({ prefix: "?", final: "h" }, (params) => {
+    if (params[0] !== 2031) return false;
+    session.mode2031 = true;
+    return true;
+  }));
+
+  // --- CSI ? 2031 l — disable Mode 2031 ---
+  d.push(terminal.parser.registerCsiHandler({ prefix: "?", final: "l" }, (params) => {
+    if (params[0] !== 2031) return false;
+    session.mode2031 = false;
+    return true;
+  }));
 }
 
 export class TerminalTabManager {
@@ -213,7 +294,13 @@ export class TerminalTabManager {
     const pty = new PtyManager(this.pluginDir);
     const session: TerminalSession = {
       id, name, terminal, fitAddon, pty, containerEl, color: "",
+      mode2031: false,
+      parserDisposables: [],
     };
+
+    // Register terminal color reporting (OSC 10/11, Mode 2031)
+    registerColorReporting(session);
+
     this.sessions.push(session);
     this.switchTab(id);
     this.renderTabBar();
@@ -292,6 +379,8 @@ export class TerminalTabManager {
     if (idx === -1) return;
 
     const session = this.sessions[idx];
+    for (const d of session.parserDisposables) d.dispose();
+    session.parserDisposables = [];
     session.pty.kill();
     session.terminal.dispose();
     session.containerEl.remove();
@@ -336,6 +425,8 @@ export class TerminalTabManager {
 
   destroyAll(): void {
     for (const session of this.sessions) {
+      for (const d of session.parserDisposables) d.dispose();
+      session.parserDisposables = [];
       session.pty.kill();
       session.terminal.dispose();
       session.containerEl.remove();
@@ -443,6 +534,24 @@ export class TerminalTabManager {
     }
     for (const session of this.sessions) {
       session.terminal.options.theme = { ...session.terminal.options.theme, background: theme.background };
+    }
+  }
+
+  /** Re-apply the full theme to all sessions (used when Obsidian switches dark/light). */
+  updateTheme(): void {
+    const theme = getTheme(this.settings.theme);
+    if (this.settings.backgroundColor) {
+      theme.background = this.settings.backgroundColor;
+    }
+    const isDark = isObsidianDark();
+    for (const session of this.sessions) {
+      session.terminal.options.theme = theme;
+
+      // Notify child apps that opted into Mode 2031 color-scheme-change updates
+      if (session.mode2031) {
+        const mode = isDark ? 1 : 2; // 1 = dark, 2 = light
+        session.pty.write(`${ESC}[?997;${mode}n`);
+      }
     }
   }
 

--- a/src/terminal-view.ts
+++ b/src/terminal-view.ts
@@ -95,4 +95,8 @@ export class TerminalView extends ItemView {
   updateBackgroundColor(): void {
     this.tabManager?.updateBackgroundColor();
   }
+
+  updateTheme(): void {
+    this.tabManager?.updateTheme();
+  }
 }

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -95,8 +95,23 @@ export const THEMES: Record<string, ITheme> = {
   },
 };
 
-export const THEME_NAMES = Object.keys(THEMES);
+export const THEME_NAMES = ["system", ...Object.keys(THEMES)];
 
+/** Detect whether Obsidian is currently in dark mode. */
+export function isObsidianDark(): boolean {
+  return document.body.classList.contains("theme-dark");
+}
+
+/**
+ * Resolve a theme name to a concrete xterm.js ITheme.
+ * When name is "system", selects obsidian-dark or obsidian-light
+ * based on Obsidian's current appearance.
+ */
 export function getTheme(name: string): ITheme {
-  return THEMES[name] || THEMES["obsidian-dark"];
+  if (name === "system") {
+    const resolved = isObsidianDark() ? "obsidian-dark" : "obsidian-light";
+    return { ...THEMES[resolved] };
+  }
+  const theme = THEMES[name];
+  return theme ? { ...theme } : { ...THEMES["obsidian-dark"] };
 }


### PR DESCRIPTION
## Summary

- Fix emoji/wide-character rendering artifacts by enabling Unicode 11 width tables
- Add "System" theme that auto-follows Obsidian's dark/light mode
- Implement standard terminal color reporting (OSC 10/11, Mode 2031) so child apps can detect and react to theme changes live

## Changes

### 1. Fix emoji rendering artifacts

Emoji characters rendered with visual artifacts (extra/overlapping pixels) because xterm.js defaulted to Unicode 6 width tables that measure emoji as 1-cell wide. Added `@xterm/addon-unicode11` which provides correct 2-cell widths for emoji and other wide characters.

**Files:** `package.json`, `src/terminal-tab-manager.ts`

### 2. System theme + terminal color reporting

**System theme (follow Obsidian):**
- New `"system"` theme option (new default) resolves to `obsidian-dark` or `obsidian-light` based on Obsidian's current appearance
- `MutationObserver` on `document.body` detects Obsidian's `theme-dark`/`theme-light` class changes and re-applies the full xterm theme to all sessions in real time
- Settings dropdown shows "System (follow Obsidian)" with description

**Terminal color reporting protocol:**
- **OSC 10/11 queries** — child apps can query foreground/background colors; replies use standard X11 `rgb:RRRR/GGGG/BBBB` format via PTY write
- **CSI ?996n** — one-shot dark/light mode query, replies `CSI ?997;1n` (dark) or `CSI ?997;2n` (light)
- **Mode 2031** (`CSI ?2031h/l`) — child apps subscribe to live color-scheme-change notifications; on theme change, subscribed sessions receive proactive `CSI ?997;Xn`

This matches the protocol implemented by Ghostty, Kitty, and Contour. Apps using the Charmbracelet stack (OpenCode, etc.) get correct initial theme detection via OSC 11 at startup. Live switching will work automatically once termenv adds Mode 2031 support.

**Files:** `src/themes.ts`, `src/main.ts`, `src/settings.ts`, `src/terminal-tab-manager.ts`, `src/terminal-view.ts`, `.gitignore`

## Testing

- [x] `npm run build` succeeds
- [x] Plugin loads in Obsidian with no errors
- [x] Terminal opens and renders correctly
- [x] Toggling Obsidian dark/light mode updates terminal colors in real time
- [x] OpenCode launched inside the terminal correctly detects initial theme