### PR TITLE
fix(zsh): forward .zshenv and .zprofile through ZDOTDIR override

### DIFF
--- a/src/shell-integration.ts
+++ b/src/shell-integration.ts
@@ -114,11 +114,16 @@ export function getShellIntegration(
   // macOS / Linux
   if (lower.includes("zsh") || lower.endsWith("/zsh")) {
     const initFile = ensureScript(scriptDir, "zsh-init.zsh", ZSH_SCRIPT);
-    // zsh reads .zshrc from ZDOTDIR; point it to our directory
-    ensureScript(scriptDir, ".zshrc", `source "${initFile}"\n`);
+    const userZdotdir = process.env.ZDOTDIR || process.env.HOME || "";
+    // zsh reads startup files from ZDOTDIR; point it to our directory and
+    // provide forwarding scripts for all three per-user config files so that
+    // the user's real environment (PATH, aliases, etc.) is fully loaded.
+    ensureScript(scriptDir, ".zshenv",   `[[ -f "${userZdotdir}/.zshenv"   ]] && source "${userZdotdir}/.zshenv"\n`);
+    ensureScript(scriptDir, ".zprofile", `[[ -f "${userZdotdir}/.zprofile" ]] && source "${userZdotdir}/.zprofile"\n`);
+    ensureScript(scriptDir, ".zshrc",    `source "${initFile}"\n`);
     return {
       env: {
-        __LOT_USER_ZDOTDIR: process.env.ZDOTDIR || process.env.HOME || "",
+        __LOT_USER_ZDOTDIR: userZdotdir,
         ZDOTDIR: scriptDir,
       },
       args: [],


### PR DESCRIPTION
## Problem

When the plugin sets `ZDOTDIR` to its own `shell-integration/` directory, zsh reads **all** startup files from that directory — not just `.zshrc`. Previously only `.zshrc` was forwarded, so two files were silently skipped:

- **`.zshenv`** — sourced for every zsh session (login, non-login, interactive, non-interactive). On macOS this is where `eval "$(/opt/homebrew/bin/brew shellenv)"` lives, so Homebrew's `/opt/homebrew/bin` was never added to `PATH`. Tools installed via Homebrew (`micro`, `bat`, `eza`, `zoxide`, etc.) were not found.
- **`.zprofile`** — sourced for login shells. Any env vars or PATH additions placed here were also skipped.

This is the root cause of #9.

## Fix

Add forwarding scripts for `.zshenv` and `.zprofile` alongside the existing `.zshrc`, using the same pattern already in place:

```
scriptDir/.zshenv   →  source $userZdotdir/.zshenv   (if exists)
scriptDir/.zprofile →  source $userZdotdir/.zprofile (if exists)
scriptDir/.zshrc    →  source zsh-init.zsh → source $userZdotdir/.zshrc
```

Both files are guarded with `[[ -f ... ]]` so they're no-ops if the user doesn't have them.

Also extracts the repeated `process.env.ZDOTDIR || process.env.HOME || ""` expression into `userZdotdir` to avoid computing it three times.

## Testing

Verified on macOS (Apple Silicon) with Homebrew. After the fix, `$PATH` includes `/opt/homebrew/bin` and all Homebrew-installed tools are accessible in the terminal.