### PR TITLE
Session management: persistence, rescue, Claude Code integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ An embedded terminal panel for [Obsidian](https://obsidian.md), powered by [xter
 - Shift+Enter inserts a newline instead of submitting (muscle memory friendly for Claude Code users)
 - Custom background color override with color picker (match your vault theme)
 - Configurable: shell path, font size, font family, cursor blink, scrollback, panel location
+- Session persistence: tabs, names, colors, working directories, and scrollback are restored when Obsidian reopens
+- Rescue recently closed tabs via command palette (ring buffer of the last 10 closed sessions by default)
+- Optional [Claude Code](https://claude.com/claude-code) integration: auto-maintained registry of sessions with clickable Resume links
 
 ## Installation
 
@@ -48,6 +51,8 @@ An embedded terminal panel for [Obsidian](https://obsidian.md), powered by [xter
 | Rename tab | Right-click the tab label |
 | Close tab | Click the **x** on the tab |
 | Split pane | Command palette: **Open terminal in new pane** |
+| Restore closed tab | Command palette: **Restore recent terminal session** — pick from recently closed tabs (and Claude sessions, if integration enabled) |
+| Refresh Claude session registry | Command palette: **Refresh Claude session registry** — rewrites the registry note (requires Claude integration enabled) |
 
 ## Settings
 
@@ -65,12 +70,34 @@ An embedded terminal panel for [Obsidian](https://obsidian.md), powered by [xter
 | Notify on completion | Off | Sound + notice when a background tab command finishes |
 | Notification sound | Beep | Choose from Beep, Chime, Ping, or Pop |
 | Notification volume | 50 | Volume for notification sounds (0–100) |
+| Persist terminal buffer | On | Save scrollback history across restarts. Disable to reduce workspace.json size |
+| Recent sessions to keep | 10 | Closed-tab rescue buffer size. Set to 0 to disable |
+| Enable Claude Code integration | Off | Scan `~/.claude/` for sessions, register the `obsidian://lean-terminal` URI handler, include Claude sessions in the restore picker |
+| Registry note path | claude-sessions.md | Vault-relative path to the auto-maintained Claude sessions registry |
+| Registry sessions to keep | 25 | Max Claude sessions listed in the registry note and picker |
 
 ## How It Works
 
 The plugin uses xterm.js for terminal rendering and node-pty for native pseudo-terminal support. node-pty spawns a real shell process (PowerShell, bash, etc.) and connects its stdin/stdout to xterm.js via Obsidian's Electron runtime. This gives you a fully interactive terminal — not just command execution.
 
 On Windows, the plugin uses the winpty backend because Obsidian's Electron renderer does not support Worker threads required by ConPTY.
+
+## Session Persistence
+
+Each terminal tab's name, color, working directory, and scrollback buffer are saved to the workspace layout on close and on Obsidian quit. On next launch, tabs are restored with their history visible and a fresh shell spawned in the saved directory. This is visual/history restore — the underlying shell process does not survive quit.
+
+Closing a tab (**x** button) pushes its state to a rescue ring buffer stored in plugin data. Use **Restore recent terminal session** from the command palette to re-open a closed tab at any point.
+
+## Claude Code Integration
+
+Disabled by default. When enabled in settings, the plugin:
+
+- Scans `~/.claude/projects/` for conversation sessions associated with the current vault
+- Generates a markdown registry note on demand (**Refresh Claude session registry** command) with clickable Resume links
+- Registers the `obsidian://lean-terminal?resume=<session-id>` URI so links in the registry (or any note) open a new terminal tab and run `claude --resume <session-id>` once the shell is ready
+- Includes Claude sessions alongside recently closed tabs in the **Restore recent terminal session** picker, sorted by most recent
+
+Sessions started by typing `claude` manually inside a tab are not auto-tracked, but appear in the picker on its next open (the scan runs fresh each time) — click to resume.
 
 ## Feedback
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
-  "name": "obsidian-terminal-plugin",
-  "version": "0.1.0",
+  "name": "lean-terminal",
+  "version": "0.6.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "obsidian-terminal-plugin",
-      "version": "0.1.0",
+      "name": "lean-terminal",
+      "version": "0.6.5",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.10.0",
+        "@xterm/addon-serialize": "^0.13.0",
         "@xterm/addon-web-links": "^0.11.0",
         "@xterm/xterm": "^5.5.0"
       },
@@ -18,7 +19,7 @@
         "builtin-modules": "^4.0.0",
         "esbuild": "^0.25.0",
         "node-pty": "^1.0.0",
-        "obsidian": "latest",
+        "obsidian": "^1.7.0",
         "typescript": "^5.8.0"
       }
     },
@@ -494,8 +495,7 @@
       "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/codemirror": {
       "version": "5.60.8",
@@ -543,6 +543,15 @@
         "@xterm/xterm": "^5.0.0"
       }
     },
+    "node_modules/@xterm/addon-serialize": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-serialize/-/addon-serialize-0.13.0.tgz",
+      "integrity": "sha512-kGs8o6LWAmN1l2NpMp01/YkpxbmO4UrfWybeGu79Khw5K9+Krp7XhXbBTOTc3GJRRhd6EmILjpR8k5+odY39YQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@xterm/xterm": "^5.0.0"
+      }
+    },
     "node_modules/@xterm/addon-web-links": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-web-links/-/addon-web-links-0.11.0.tgz",
@@ -556,7 +565,8 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
       "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/builtin-modules": {
       "version": "4.0.0",
@@ -576,8 +586,7 @@
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -669,8 +678,7 @@
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
       "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -698,8 +706,7 @@
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,12 @@
     "dev": "node esbuild.config.mjs",
     "build": "tsc -noEmit -skipLibCheck && node esbuild.config.mjs production"
   },
-  "keywords": ["obsidian", "terminal", "xterm", "pty"],
+  "keywords": [
+    "obsidian",
+    "terminal",
+    "xterm",
+    "pty"
+  ],
   "license": "MIT",
   "devDependencies": {
     "@types/node": "^22.0.0",
@@ -18,8 +23,9 @@
     "typescript": "^5.8.0"
   },
   "dependencies": {
-    "@xterm/xterm": "^5.5.0",
     "@xterm/addon-fit": "^0.10.0",
-    "@xterm/addon-web-links": "^0.11.0"
+    "@xterm/addon-serialize": "^0.13.0",
+    "@xterm/addon-web-links": "^0.11.0",
+    "@xterm/xterm": "^5.5.0"
   }
 }

--- a/src/claude-sessions.ts
+++ b/src/claude-sessions.ts
@@ -1,0 +1,270 @@
+import { Notice, TFile, FileSystemAdapter } from "obsidian";
+import type TerminalPlugin from "./main";
+import { openTabOrView } from "./terminal-opener";
+
+export interface ClaudeSessionEntry {
+  sessionId: string;
+  cwd: string;
+  firstPrompt: string;
+  summary: string;
+  modified: string; // ISO 8601
+  messageCount: number;
+  gitBranch: string;
+}
+
+interface SessionsIndexEntry {
+  sessionId: string;
+  firstPrompt?: string;
+  summary?: string;
+  modified?: string;
+  messageCount?: number;
+  gitBranch?: string;
+}
+
+/**
+ * Encode a filesystem path the way Claude Code does for its project directories.
+ * Any character outside [A-Za-z0-9-] becomes a hyphen.
+ * E.g. "C:\\_fg2" -> "C---fg2", "/home/user" -> "-home-user".
+ */
+export function encodeProjectDir(cwd: string): string {
+  return cwd.replace(/[^a-zA-Z0-9-]/g, "-");
+}
+
+/**
+ * Scan ~/.claude/projects/<encoded>/ for session JSONL files.
+ * Cross-references sessions-index.json for AI-generated summaries.
+ * Returns entries sorted by modified desc, capped at `max`.
+ */
+export async function scanClaudeProjectSessions(
+  cwd: string,
+  max: number
+): Promise<ClaudeSessionEntry[]> {
+  const path = window.require("path") as typeof import("path");
+  const os = window.require("os") as typeof import("os");
+  const fs = (window.require("fs") as typeof import("fs")).promises;
+
+  const encoded = encodeProjectDir(cwd);
+  const projectDir = path.join(os.homedir(), ".claude", "projects", encoded);
+
+  let files: string[];
+  try {
+    files = (await fs.readdir(projectDir)).filter((f) => f.endsWith(".jsonl"));
+  } catch {
+    return []; // no project directory for this vault
+  }
+
+  const indexMap = await readSessionsIndex(projectDir);
+
+  const entries: ClaudeSessionEntry[] = [];
+  for (const file of files) {
+    const fullPath = path.join(projectDir, file);
+    const sessionId = file.replace(/\.jsonl$/, "");
+    const indexed = indexMap.get(sessionId);
+
+    let firstPrompt = indexed?.firstPrompt ?? "";
+    let modified = indexed?.modified ?? "";
+    const messageCount = indexed?.messageCount ?? 0;
+    const gitBranch = indexed?.gitBranch ?? "";
+    const summary = indexed?.summary ?? "";
+
+    // Fill gaps from the JSONL itself (the sessions-index.json can lag)
+    if (!firstPrompt || !modified) {
+      try {
+        if (!modified) {
+          const stat = await fs.stat(fullPath);
+          modified = stat.mtime.toISOString();
+        }
+        if (!firstPrompt) {
+          firstPrompt = await readFirstUserPrompt(fullPath);
+        }
+      } catch {
+        continue; // skip unreadable files
+      }
+    }
+
+    entries.push({
+      sessionId,
+      cwd,
+      firstPrompt: cleanPrompt(firstPrompt),
+      summary: cleanPrompt(summary),
+      modified,
+      messageCount,
+      gitBranch,
+    });
+  }
+
+  entries.sort((a, b) => b.modified.localeCompare(a.modified));
+  return entries.slice(0, max);
+}
+
+async function readSessionsIndex(projectDir: string): Promise<Map<string, SessionsIndexEntry>> {
+  const path = window.require("path") as typeof import("path");
+  const fs = (window.require("fs") as typeof import("fs")).promises;
+  const map = new Map<string, SessionsIndexEntry>();
+
+  try {
+    const indexPath = path.join(projectDir, "sessions-index.json");
+    const content = await fs.readFile(indexPath, "utf-8");
+    const data = JSON.parse(content) as { entries?: SessionsIndexEntry[] };
+    if (Array.isArray(data.entries)) {
+      for (const e of data.entries) {
+        if (e.sessionId) map.set(e.sessionId, e);
+      }
+    }
+  } catch {
+    // missing or malformed index — scanner falls back to JSONL stats
+  }
+  return map;
+}
+
+/** Read the first user (non-meta) message in a JSONL session file, truncated. */
+async function readFirstUserPrompt(filePath: string): Promise<string> {
+  const fs = (window.require("fs") as typeof import("fs")).promises;
+  try {
+    const content = await fs.readFile(filePath, "utf-8");
+    const lines = content.split("\n");
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      let msg: Record<string, unknown>;
+      try {
+        msg = JSON.parse(line) as Record<string, unknown>;
+      } catch {
+        continue;
+      }
+      if (msg.type !== "user" || msg.isMeta) continue;
+      const message = msg.message as { content?: unknown } | undefined;
+      const content = message?.content;
+      if (typeof content === "string") return truncate(content);
+      if (Array.isArray(content)) {
+        for (const block of content) {
+          if (
+            block && typeof block === "object" &&
+            (block as { type?: unknown }).type === "text" &&
+            typeof (block as { text?: unknown }).text === "string"
+          ) {
+            return truncate((block as { text: string }).text);
+          }
+        }
+      }
+    }
+  } catch {
+    // IO error — return empty string
+  }
+  return "";
+}
+
+/**
+ * Clean a prompt string that may contain Claude Code slash-command markup
+ * (e.g. "<command-name>/model</command-name> <command-message>model</command-message>...").
+ * Extracts the command name if present; otherwise strips any stray HTML-like tags.
+ */
+function cleanPrompt(raw: string): string {
+  if (!raw) return "";
+  const cmdMatch = raw.match(/<command-name>([^<]+)<\/command-name>/);
+  if (cmdMatch) return cmdMatch[1].trim();
+  return raw.replace(/<[^>]+>/g, "").replace(/\s+/g, " ").trim();
+}
+
+function truncate(s: string, max = 100): string {
+  const oneline = cleanPrompt(s);
+  return oneline.length > max ? oneline.slice(0, max - 1) + "\u2026" : oneline;
+}
+
+/**
+ * Refresh the Claude session registry note.
+ * Writes a markdown table at the configured path; creates the file if missing.
+ */
+export async function refreshClaudeRegistry(plugin: TerminalPlugin): Promise<void> {
+  if (!plugin.settings.enableClaudeIntegration) {
+    new Notice("Enable Claude Code integration in settings first.");
+    return;
+  }
+
+  const cwd = getVaultBasePath(plugin);
+  if (!cwd) {
+    new Notice("Could not determine vault path.");
+    return;
+  }
+
+  const entries = await scanClaudeProjectSessions(cwd, plugin.settings.claudeSessionsMax);
+  const markdown = generateRegistryMarkdown(entries);
+
+  try {
+    const abstract = plugin.app.vault.getAbstractFileByPath(plugin.settings.claudeRegistryPath);
+    if (abstract instanceof TFile) {
+      await plugin.app.vault.modify(abstract, markdown);
+    } else {
+      await plugin.app.vault.create(plugin.settings.claudeRegistryPath, markdown);
+    }
+    new Notice(`Claude registry: ${entries.length} session${entries.length === 1 ? "" : "s"}.`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    new Notice(`Failed to write registry: ${msg}`);
+  }
+}
+
+function generateRegistryMarkdown(entries: ClaudeSessionEntry[]): string {
+  const header = [
+    "# Claude Sessions",
+    "",
+    `*Auto-maintained by Lean Terminal — last refreshed ${new Date().toISOString()}. Click a Resume link to reopen that Claude Code conversation in a new terminal tab.*`,
+    "",
+    "",
+  ].join("\n");
+
+  if (entries.length === 0) {
+    return header + "*No Claude sessions found for this vault.*\n";
+  }
+
+  const rows = entries.map((e) => {
+    const title = e.summary || e.firstPrompt || `(session ${e.sessionId.slice(0, 8)})`;
+    const branch = e.gitBranch || "\u2014";
+    const modified = e.modified ? e.modified.slice(0, 10) : "\u2014";
+    const msgs = e.messageCount > 0 ? String(e.messageCount) : "\u2014";
+    const resumeUri = `obsidian://lean-terminal?resume=${e.sessionId}`;
+    return `| ${escapeTableCell(title)} | ${branch} | ${msgs} | ${modified} | [Resume](${resumeUri}) |`;
+  });
+
+  return header + [
+    "| Session | Branch | Messages | Modified | |",
+    "|---------|--------|----------|----------|--|",
+    ...rows,
+    "",
+  ].join("\n");
+}
+
+function escapeTableCell(s: string): string {
+  return s.replace(/\|/g, "\\|").replace(/\n/g, " ");
+}
+
+/**
+ * Open a terminal tab that runs `claude --resume <sessionId>` on shell spawn.
+ * Called from the obsidian://lean-terminal?resume=... protocol handler.
+ */
+export async function resumeClaudeSession(
+  plugin: TerminalPlugin,
+  sessionId: string
+): Promise<void> {
+  if (!plugin.settings.enableClaudeIntegration) {
+    new Notice("Claude integration is disabled in settings.");
+    return;
+  }
+
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(sessionId)) {
+    new Notice("Invalid Claude session ID.");
+    return;
+  }
+
+  await openTabOrView(plugin, {
+    name: `Claude ${sessionId.slice(0, 8)}`,
+    color: "",
+    cwd: getVaultBasePath(plugin),
+    resumeCommand: `claude --resume ${sessionId}`,
+  });
+}
+
+function getVaultBasePath(plugin: TerminalPlugin): string {
+  const adapter = plugin.app.vault.adapter;
+  if (adapter instanceof FileSystemAdapter) return adapter.getBasePath();
+  return "";
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,8 @@ import { VIEW_TYPE_TERMINAL } from "./constants";
 import { TerminalView } from "./terminal-view";
 import { TerminalSettingTab, DEFAULT_SETTINGS, type TerminalPluginSettings } from "./settings";
 import { BinaryManager } from "./binary-manager";
+import { openRecentSessionPicker } from "./recent-sessions";
+import { refreshClaudeRegistry, resumeClaudeSession } from "./claude-sessions";
 
 export default class TerminalPlugin extends Plugin {
   settings: TerminalPluginSettings = DEFAULT_SETTINGS;
@@ -63,8 +65,38 @@ export default class TerminalPlugin extends Plugin {
       callback: () => void this.openTerminalInNewPane(),
     });
 
+    this.addCommand({
+      id: "restore-recent-terminal-session",
+      name: "Restore recent terminal session",
+      callback: () => void openRecentSessionPicker(this),
+    });
+
+    this.addCommand({
+      id: "refresh-claude-session-registry",
+      name: "Refresh Claude session registry",
+      callback: () => void refreshClaudeRegistry(this),
+    });
+
+    // URI handler for clickable resume links in the registry note.
+    // Gating happens inside resumeClaudeSession — the handler is always registered
+    // so that flipping the setting doesn't require a plugin reload.
+    this.registerObsidianProtocolHandler("lean-terminal", (params) => {
+      if (params.resume) {
+        void resumeClaudeSession(this, params.resume);
+      }
+    });
+
     // Settings tab
     this.addSettingTab(new TerminalSettingTab(this.app, this));
+
+    // Flush any pending layout save before Obsidian quits. Without this, a
+    // typed-then-quickly-quit scenario loses the last few seconds of activity
+    // because Obsidian's requestSaveLayout is debounced.
+    this.registerEvent(
+      this.app.workspace.on("quit", () => {
+        this.app.workspace.requestSaveLayout.run();
+      })
+    );
   }
 
   onunload(): void {

--- a/src/recent-sessions.ts
+++ b/src/recent-sessions.ts
@@ -1,0 +1,149 @@
+import { FuzzySuggestModal, Notice, FileSystemAdapter } from "obsidian";
+import type TerminalPlugin from "./main";
+import type { RecentSession, SavedTab } from "./session-state";
+import type { CreateTabOpts } from "./terminal-tab-manager";
+import { openTabOrView } from "./terminal-opener";
+import {
+  scanClaudeProjectSessions,
+  type ClaudeSessionEntry,
+} from "./claude-sessions";
+
+/**
+ * Push a closed tab onto the recents ring buffer, trimmed to the configured max.
+ * Called from TerminalTabManager via the onSessionClose callback.
+ */
+export async function pushRecentSession(plugin: TerminalPlugin, tab: SavedTab): Promise<void> {
+  const max = plugin.settings.recentSessionsMax;
+  if (max <= 0) return;
+
+  const entry: RecentSession = { ...tab, closedAt: Date.now() };
+  plugin.settings.recentSessions.unshift(entry);
+  if (plugin.settings.recentSessions.length > max) {
+    plugin.settings.recentSessions.length = max;
+  }
+  await plugin.saveSettings();
+}
+
+/**
+ * Open the unified "Restore recent terminal session" picker.
+ * Shows recents always; also shows Claude sessions when that integration is enabled.
+ */
+export async function openRecentSessionPicker(plugin: TerminalPlugin): Promise<void> {
+  const recents = plugin.settings.recentSessions;
+
+  let claudeEntries: ClaudeSessionEntry[] = [];
+  if (plugin.settings.enableClaudeIntegration) {
+    const cwd = getVaultBasePath(plugin);
+    if (cwd) {
+      claudeEntries = await scanClaudeProjectSessions(cwd, plugin.settings.claudeSessionsMax);
+    }
+  }
+
+  if (recents.length === 0 && claudeEntries.length === 0) {
+    new Notice("No recent or Claude sessions to restore.");
+    return;
+  }
+
+  const items: PickerItem[] = [
+    ...recents.map((s): PickerItem => ({ kind: "recent", session: s, ts: s.closedAt })),
+    ...claudeEntries.map((s): PickerItem => ({
+      kind: "claude",
+      session: s,
+      ts: s.modified ? Date.parse(s.modified) : 0,
+    })),
+  ];
+
+  // Merge by recency — most recent first, regardless of source
+  items.sort((a, b) => b.ts - a.ts);
+
+  new UnifiedSessionPicker(plugin, items).open();
+}
+
+type PickerItem =
+  | { kind: "recent"; session: RecentSession; ts: number }
+  | { kind: "claude"; session: ClaudeSessionEntry; ts: number };
+
+class UnifiedSessionPicker extends FuzzySuggestModal<PickerItem> {
+  private plugin: TerminalPlugin;
+  private items: PickerItem[];
+
+  constructor(plugin: TerminalPlugin, items: PickerItem[]) {
+    super(plugin.app);
+    this.plugin = plugin;
+    this.items = items;
+    this.setPlaceholder("Pick a session to restore…");
+  }
+
+  getItems(): PickerItem[] {
+    return this.items;
+  }
+
+  getItemText(item: PickerItem): string {
+    if (item.kind === "recent") {
+      const s = item.session;
+      const age = relativeTime(Date.now() - s.closedAt);
+      return `[Recent] ${s.name} — ${s.cwd} (${age})`;
+    }
+    const s = item.session;
+    const title = s.summary || s.firstPrompt || `(${s.sessionId.slice(0, 8)})`;
+    const when = s.modified ? s.modified.slice(0, 10) : "unknown";
+    return `[Claude] ${title} (${when})`;
+  }
+
+  onChooseItem(item: PickerItem): void {
+    if (item.kind === "recent") {
+      void restoreRecent(this.plugin, item.session);
+    } else {
+      void restoreClaude(this.plugin, item.session);
+    }
+  }
+}
+
+/**
+ * Restore a recent terminal session: create a tab (or open a view) with the saved state.
+ * Consumes the entry from recents — closing the tab again will re-add it.
+ */
+async function restoreRecent(plugin: TerminalPlugin, session: RecentSession): Promise<void> {
+  const idx = plugin.settings.recentSessions.indexOf(session);
+  if (idx >= 0) {
+    plugin.settings.recentSessions.splice(idx, 1);
+    await plugin.saveSettings();
+  }
+
+  const opts: CreateTabOpts = {
+    name: session.name,
+    color: session.color,
+    cwd: session.cwd,
+    bufferSerial: session.bufferSerial,
+    resumeCommand: session.resumeCommand,
+  };
+  await openTabOrView(plugin, opts);
+}
+
+/** Restore a Claude Code session by running `claude --resume <uuid>` in a new tab. */
+async function restoreClaude(plugin: TerminalPlugin, entry: ClaudeSessionEntry): Promise<void> {
+  const opts: CreateTabOpts = {
+    name: `Claude ${entry.sessionId.slice(0, 8)}`,
+    color: "",
+    cwd: entry.cwd || getVaultBasePath(plugin),
+    resumeCommand: `claude --resume ${entry.sessionId}`,
+  };
+  await openTabOrView(plugin, opts);
+}
+
+function getVaultBasePath(plugin: TerminalPlugin): string {
+  const adapter = plugin.app.vault.adapter;
+  if (adapter instanceof FileSystemAdapter) return adapter.getBasePath();
+  return "";
+}
+
+function relativeTime(ms: number): string {
+  const sec = Math.floor(ms / 1000);
+  if (sec < 60) return sec <= 1 ? "just now" : `${sec}s ago`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const days = Math.floor(hr / 24);
+  return `${days}d ago`;
+}

--- a/src/session-state.ts
+++ b/src/session-state.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared types for terminal session persistence.
+ *
+ * SavedTab is the unit of persistence — one per terminal session (tab).
+ * SavedViewState is what TerminalView.getState/setState serialize.
+ */
+
+export interface SavedTab {
+  /** User-visible tab name (e.g. "Terminal 3" or a renamed value). */
+  name: string;
+  /** Tab accent color (hex or empty). Matches TAB_COLORS values. */
+  color: string;
+  /** Working directory when the session was started. */
+  cwd: string;
+  /**
+   * Serialized xterm.js buffer (from @xterm/addon-serialize).
+   * Absent when persistBuffer setting is off, or when nothing has been written yet.
+   */
+  bufferSerial?: string;
+  /**
+   * Command to run after the shell spawns on restore
+   * (e.g. "claude --resume <uuid>"). Reserved for Stage C.
+   */
+  resumeCommand?: string;
+}
+
+export interface SavedViewState {
+  /** Tabs in their original left-to-right order. */
+  tabs: SavedTab[];
+  /** Index of the tab that was active when state was captured. */
+  activeIndex: number;
+}
+
+/**
+ * A SavedTab captured at close time, for the recent-sessions rescue buffer.
+ * Stored in plugin data (data.json), not in workspace.json.
+ */
+export interface RecentSession extends SavedTab {
+  /** Epoch ms when the tab was closed. */
+  closedAt: number;
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,6 +1,7 @@
 import { App, Notice, PluginSettingTab, Setting, ColorComponent, setIcon } from "obsidian";
 import type TerminalPlugin from "./main";
 import { THEME_NAMES } from "./themes";
+import type { RecentSession } from "./session-state";
 
 export type NotificationSound = "beep" | "chime" | "ping" | "pop";
 
@@ -17,6 +18,13 @@ export interface TerminalPluginSettings {
   notifyOnCompletion: boolean;
   notificationSound: NotificationSound;
   notificationVolume: number;
+  persistBuffer: boolean;
+  recentSessionsMax: number;
+  recentSessions: RecentSession[];
+  // Claude Code integration — all gated on enableClaudeIntegration
+  enableClaudeIntegration: boolean;
+  claudeRegistryPath: string;
+  claudeSessionsMax: number;
 }
 
 export const DEFAULT_SETTINGS: TerminalPluginSettings = {
@@ -32,6 +40,12 @@ export const DEFAULT_SETTINGS: TerminalPluginSettings = {
   notifyOnCompletion: false,
   notificationSound: "beep",
   notificationVolume: 50,
+  persistBuffer: true,
+  recentSessionsMax: 10,
+  recentSessions: [],
+  enableClaudeIntegration: false,
+  claudeRegistryPath: "claude-sessions.md",
+  claudeSessionsMax: 25,
 };
 
 export class TerminalSettingTab extends PluginSettingTab {
@@ -310,5 +324,91 @@ export class TerminalSettingTab extends PluginSettingTab {
             await this.plugin.saveSettings();
           })
       );
+
+    // --- Session Persistence ---
+    new Setting(containerEl).setName("Session persistence").setHeading();
+
+    new Setting(containerEl)
+      .setName("Persist terminal buffer")
+      .setDesc(
+        "Save scrollback history across restarts so restored tabs show prior output. Disable to reduce workspace.json size."
+      )
+      .addToggle((toggle) =>
+        toggle.setValue(this.plugin.settings.persistBuffer).onChange(async (value) => {
+          this.plugin.settings.persistBuffer = value;
+          await this.plugin.saveSettings();
+        })
+      );
+
+    new Setting(containerEl)
+      .setName("Recent sessions to keep")
+      .setDesc(
+        "When a tab is closed, its state is kept for rescue via \"Restore recent terminal session\". Set to 0 to disable."
+      )
+      .addText((text) =>
+        text
+          .setValue(String(this.plugin.settings.recentSessionsMax))
+          .onChange(async (value) => {
+            const num = parseInt(value, 10);
+            if (!isNaN(num) && num >= 0) {
+              this.plugin.settings.recentSessionsMax = num;
+              // Trim the existing ring buffer if the new max is smaller
+              if (this.plugin.settings.recentSessions.length > num) {
+                this.plugin.settings.recentSessions.length = num;
+              }
+              await this.plugin.saveSettings();
+            }
+          })
+      );
+
+    // --- Claude Code Integration ---
+    new Setting(containerEl).setName("Claude Code integration").setHeading();
+
+    new Setting(containerEl)
+      .setName("Enable Claude Code integration")
+      .setDesc(
+        "Scan ~/.claude/ for conversation sessions, register the obsidian://lean-terminal URI handler for resume links, and show Claude sessions in the restore picker."
+      )
+      .addToggle((toggle) =>
+        toggle.setValue(this.plugin.settings.enableClaudeIntegration).onChange(async (value) => {
+          this.plugin.settings.enableClaudeIntegration = value;
+          await this.plugin.saveSettings();
+          this.display(); // rebuild UI to show/hide Claude-specific settings
+        })
+      );
+
+    if (this.plugin.settings.enableClaudeIntegration) {
+      new Setting(containerEl)
+        .setName("Registry note path")
+        .setDesc(
+          "Vault-relative path to the auto-generated Claude sessions registry note. Created on first refresh."
+        )
+        .addText((text) =>
+          text
+            .setPlaceholder("claude-sessions.md")
+            .setValue(this.plugin.settings.claudeRegistryPath)
+            .onChange(async (value) => {
+              this.plugin.settings.claudeRegistryPath = value.trim() || "claude-sessions.md";
+              await this.plugin.saveSettings();
+            })
+        );
+
+      new Setting(containerEl)
+        .setName("Registry sessions to keep")
+        .setDesc(
+          "Maximum number of most-recent Claude sessions to list in the registry note and picker. Older sessions remain accessible via /resume."
+        )
+        .addText((text) =>
+          text
+            .setValue(String(this.plugin.settings.claudeSessionsMax))
+            .onChange(async (value) => {
+              const num = parseInt(value, 10);
+              if (!isNaN(num) && num > 0) {
+                this.plugin.settings.claudeSessionsMax = num;
+                await this.plugin.saveSettings();
+              }
+            })
+        );
+    }
   }
 }

--- a/src/terminal-opener.ts
+++ b/src/terminal-opener.ts
@@ -1,0 +1,42 @@
+import type TerminalPlugin from "./main";
+import type { CreateTabOpts } from "./terminal-tab-manager";
+import type { TerminalView } from "./terminal-view";
+import { VIEW_TYPE_TERMINAL } from "./constants";
+
+/**
+ * Open a tab in the existing terminal view, or open a fresh view and replace
+ * its default tab with our opts. We can't round-trip opts through setViewState's
+ * state field because CreateTabOpts fields like `runResumeCommand` aren't part
+ * of SavedTab — they're transient creation hints. Destroy-and-recreate
+ * preserves them; the default tab has no user activity yet, so saveToRecents=false.
+ */
+export async function openTabOrView(plugin: TerminalPlugin, opts: CreateTabOpts): Promise<void> {
+  const existingLeaves = plugin.app.workspace.getLeavesOfType(VIEW_TYPE_TERMINAL);
+  if (existingLeaves.length > 0) {
+    const view = existingLeaves[0].view as TerminalView;
+    const manager = view.getTabManager();
+    if (manager) {
+      manager.createTab(opts);
+      void plugin.app.workspace.revealLeaf(existingLeaves[0]);
+      return;
+    }
+  }
+
+  const leaf =
+    plugin.settings.defaultLocation === "right"
+      ? plugin.app.workspace.getRightLeaf(false)
+      : plugin.app.workspace.getLeaf("split", "horizontal");
+  if (!leaf) return;
+
+  await leaf.setViewState({ type: VIEW_TYPE_TERMINAL, active: true });
+  void plugin.app.workspace.revealLeaf(leaf);
+
+  const view = leaf.view as TerminalView;
+  const manager = view.getTabManager();
+  if (!manager) return;
+
+  // onOpen just created a default tab (no saved state came in via setViewState);
+  // replace it with our configured tab.
+  manager.destroyAll(false);
+  manager.createTab(opts);
+}

--- a/src/terminal-tab-manager.ts
+++ b/src/terminal-tab-manager.ts
@@ -2,11 +2,13 @@ import { Notice } from "obsidian";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
+import { SerializeAddon } from "@xterm/addon-serialize";
 import { PtyManager } from "./pty-manager";
 import { getTheme } from "./themes";
 import type { TerminalPluginSettings } from "./settings";
 import type { NotificationSound } from "./settings";
 import type { BinaryManager } from "./binary-manager";
+import type { SavedTab } from "./session-state";
 
 export const TAB_COLORS = [
   { name: "None", value: "" },
@@ -23,9 +25,23 @@ export interface TerminalSession {
   name: string;
   terminal: Terminal;
   fitAddon: FitAddon;
+  serializeAddon: SerializeAddon;
   pty: PtyManager;
   containerEl: HTMLElement;
   color: string;
+  /** Working directory the shell was spawned in. */
+  cwd: string;
+  /** Reserved for Stage C: command to re-run on restore (e.g. "claude --resume <uuid>"). */
+  resumeCommand?: string;
+}
+
+/** Options for restoring a tab from persisted state (via setState). */
+export interface CreateTabOpts {
+  name?: string;
+  color?: string;
+  cwd?: string;
+  bufferSerial?: string;
+  resumeCommand?: string;
 }
 
 let sessionCounter = 0;
@@ -120,6 +136,10 @@ export class TerminalTabManager {
   private binaryManager: BinaryManager;
   private onActiveChange?: () => void;
   private onTabsEmpty?: () => void;
+  private requestSaveLayout?: () => void;
+  private onSessionClose?: (tab: SavedTab) => void;
+  /** Set true by any terminal write/resize; consumed by the view's periodic save timer. */
+  private outputDirty = false;
 
   constructor(
     tabBarEl: HTMLElement,
@@ -129,7 +149,9 @@ export class TerminalTabManager {
     pluginDir: string,
     binaryManager: BinaryManager,
     onActiveChange?: () => void,
-    onTabsEmpty?: () => void
+    onTabsEmpty?: () => void,
+    requestSaveLayout?: () => void,
+    onSessionClose?: (tab: SavedTab) => void
   ) {
     this.tabBarEl = tabBarEl;
     this.terminalHostEl = terminalHostEl;
@@ -139,12 +161,71 @@ export class TerminalTabManager {
     this.binaryManager = binaryManager;
     this.onActiveChange = onActiveChange;
     this.onTabsEmpty = onTabsEmpty;
+    this.requestSaveLayout = requestSaveLayout;
+    this.onSessionClose = onSessionClose;
   }
 
-  createTab(): TerminalSession {
+  /** Capture a session's current state as a SavedTab (used on close for recents). */
+  private captureSession(session: TerminalSession): SavedTab {
+    return {
+      name: session.name,
+      color: session.color,
+      cwd: session.cwd,
+      bufferSerial: this.settings.persistBuffer ? session.serializeAddon.serialize() : undefined,
+      resumeCommand: session.resumeCommand,
+    };
+  }
+
+  /**
+   * Consume the dirty flag: returns true if output/resize happened since last call,
+   * resetting it. Used by the view's periodic save timer.
+   */
+  consumeOutputDirty(): boolean {
+    const was = this.outputDirty;
+    this.outputDirty = false;
+    return was;
+  }
+
+  /**
+   * Install an OSC 133 handler + fallback timer that writes `resumeCommand` to the
+   * PTY once the shell is ready (signalled by OSC 133 A). Called from createTab
+   * before pty.spawn so the handler catches the very first prompt.
+   */
+  private setupAutoResume(session: TerminalSession, terminal: Terminal): void {
+    let executed = false;
+    let fallbackTimer: ReturnType<typeof setTimeout> | null = null;
+    let oscDisposable: { dispose: () => void } | null = null;
+
+    const cleanup = (): void => {
+      if (fallbackTimer) { clearTimeout(fallbackTimer); fallbackTimer = null; }
+      if (oscDisposable) { oscDisposable.dispose(); oscDisposable = null; }
+    };
+
+    const runCommand = (): void => {
+      if (executed || !session.resumeCommand) return;
+      executed = true;
+      cleanup();
+      const command = session.resumeCommand;
+      session.resumeCommand = undefined;
+      session.pty.write(command + "\r");
+      this.requestSaveLayout?.();
+    };
+
+    // Primary trigger: shell emits OSC 133 A ("prompt start") when ready for input
+    oscDisposable = terminal.parser.registerOscHandler(133, (data) => {
+      if (data.startsWith("A")) runCommand();
+      return false; // allow other handlers to run
+    });
+
+    // Fallback for shells without OSC 133 support (e.g. cmd.exe): run after 2s
+    fallbackTimer = setTimeout(runCommand, 2000);
+  }
+
+  createTab(opts?: CreateTabOpts): TerminalSession {
     sessionCounter++;
     const id = `terminal-${sessionCounter}`;
-    const name = `Terminal ${sessionCounter}`;
+    const name = opts?.name ?? `Terminal ${sessionCounter}`;
+    const sessionCwd = opts?.cwd ?? this.cwd;
 
     // Create container for this session
     const containerEl = this.terminalHostEl.createDiv({ cls: "terminal-session" });
@@ -164,10 +245,26 @@ export class TerminalTabManager {
 
     const fitAddon = new FitAddon();
     const webLinksAddon = new WebLinksAddon();
+    const serializeAddon = new SerializeAddon();
 
     terminal.loadAddon(fitAddon);
     terminal.loadAddon(webLinksAddon);
+    terminal.loadAddon(serializeAddon);
     terminal.open(containerEl);
+
+    // Replay prior buffer (from persisted state) before the PTY produces new output.
+    // No visual marker is written — markers become part of the serialized buffer and
+    // accumulate across restores.
+    if (opts?.bufferSerial) {
+      terminal.write(opts.bufferSerial);
+    }
+
+    // Mark "output changed since last save" so the view's periodic timer can
+    // trigger a save. We avoid calling requestSaveLayout on every write because
+    // heavy output (e.g. Claude streaming) caused visible input lag when every
+    // chunk scheduled a debounced save-which-serializes-the-whole-buffer.
+    terminal.onWriteParsed(() => { this.outputDirty = true; });
+    terminal.onResize(() => { this.outputDirty = true; });
 
     // Intercept clipboard shortcuts — Obsidian captures them before xterm.js
     terminal.attachCustomKeyEventHandler((e: KeyboardEvent) => {
@@ -206,14 +303,35 @@ export class TerminalTabManager {
 
     const pty = new PtyManager(this.pluginDir);
     const session: TerminalSession = {
-      id, name, terminal, fitAddon, pty, containerEl, color: "",
+      id,
+      name,
+      terminal,
+      fitAddon,
+      serializeAddon,
+      pty,
+      containerEl,
+      color: opts?.color ?? "",
+      cwd: sessionCwd,
+      resumeCommand: opts?.resumeCommand,
     };
     this.sessions.push(session);
     this.switchTab(id);
     this.renderTabBar();
+    this.requestSaveLayout?.();
+
+    // Install the auto-resume OSC listener before the PTY spawns so the first
+    // prompt's OSC 133 A is caught. Any tab with a `resumeCommand` set runs it
+    // once the shell is ready. Callers that don't want this just omit the field.
+    if (session.resumeCommand) {
+      this.setupAutoResume(session, terminal);
+    }
 
     // Defer PTY spawn until DOM is laid out so fitAddon gets correct dimensions
     setTimeout(() => {
+      // Abort if the session was destroyed while waiting (e.g. openTabOrView
+      // destroy-and-recreate flow replaces a default tab during this 100ms window)
+      if (!this.sessions.some((s) => s.id === session.id)) return;
+
       try {
         fitAddon.fit();
       } catch {
@@ -230,7 +348,7 @@ export class TerminalTabManager {
       }
 
       try {
-        pty.spawn(this.settings.shellPath, this.cwd, cols, rows);
+        pty.spawn(this.settings.shellPath, sessionCwd, cols, rows);
       } catch (err) {
         const message = err instanceof Error ? err.message : "unknown error";
         console.error("Terminal: failed to spawn shell", err);
@@ -279,6 +397,7 @@ export class TerminalTabManager {
 
     this.renderTabBar();
     this.onActiveChange?.();
+    this.requestSaveLayout?.();
   }
 
   closeTab(id: string): void {
@@ -286,6 +405,10 @@ export class TerminalTabManager {
     if (idx === -1) return;
 
     const session = this.sessions[idx];
+
+    // Capture for recents BEFORE destroying (serialize needs a live xterm)
+    this.onSessionClose?.(this.captureSession(session));
+
     session.pty.kill();
     session.terminal.dispose();
     session.containerEl.remove();
@@ -307,6 +430,7 @@ export class TerminalTabManager {
     }
 
     this.renderTabBar();
+    this.requestSaveLayout?.();
   }
 
   fitActive(): void {
@@ -328,8 +452,35 @@ export class TerminalTabManager {
     return this.sessions;
   }
 
-  destroyAll(): void {
+  /**
+   * Serialize all sessions into a form suitable for TerminalView.getState().
+   * Buffer serialization is gated on the persistBuffer setting.
+   */
+  serializeSessions(): SavedTab[] {
+    return this.sessions.map((s) => this.captureSession(s));
+  }
+
+  /** Index of the currently active session (0-based), or -1 if none. */
+  getActiveIndex(): number {
+    return this.sessions.findIndex((s) => s.id === this.activeId);
+  }
+
+  /** Activate a session by its position in the sessions array. */
+  switchToIndex(index: number): void {
+    if (index < 0 || index >= this.sessions.length) return;
+    this.switchTab(this.sessions[index].id);
+  }
+
+  /**
+   * Destroy all sessions. Pushes each to onSessionClose (recents) by default.
+   * Pass `saveToRecents: false` when replacing tabs with restored state
+   * (e.g. setState after onOpen's default-tab creation) to avoid polluting recents.
+   */
+  destroyAll(saveToRecents = true): void {
     for (const session of this.sessions) {
+      if (saveToRecents) {
+        this.onSessionClose?.(this.captureSession(session));
+      }
       session.pty.kill();
       session.terminal.dispose();
       session.containerEl.remove();
@@ -363,6 +514,7 @@ export class TerminalTabManager {
       const newName = input.value.trim() || session.name;
       session.name = newName;
       this.renderTabBar();
+      this.requestSaveLayout?.();
     };
 
     input.addEventListener("blur", commit);
@@ -414,6 +566,7 @@ export class TerminalTabManager {
       swatch.addEventListener("click", () => {
         session.color = c.value;
         this.renderTabBar();
+        this.requestSaveLayout?.();
         menu.remove();
       });
     }

--- a/src/terminal-view.ts
+++ b/src/terminal-view.ts
@@ -1,13 +1,20 @@
-import { FileSystemAdapter, ItemView, WorkspaceLeaf } from "obsidian";
+import { FileSystemAdapter, ItemView, WorkspaceLeaf, type ViewStateResult } from "obsidian";
 import { VIEW_TYPE_TERMINAL } from "./constants";
 import { TerminalTabManager } from "./terminal-tab-manager";
+import { pushRecentSession } from "./recent-sessions";
 import type TerminalPlugin from "./main";
+import type { SavedViewState } from "./session-state";
 
 export class TerminalView extends ItemView {
   private plugin: TerminalPlugin;
   private tabManager: TerminalTabManager | null = null;
   private resizeObserver: ResizeObserver | null = null;
   private resizeTimer: ReturnType<typeof setTimeout> | null = null;
+  /**
+   * State passed to setState() before onOpen() has constructed the tab manager.
+   * Applied in onOpen() once the manager is ready.
+   */
+  private pendingState: SavedViewState | null = null;
 
   constructor(leaf: WorkspaceLeaf, plugin: TerminalPlugin) {
     super(leaf);
@@ -62,9 +69,19 @@ export class TerminalView extends ItemView {
       pluginDir,
       this.plugin.binaryManager,
       undefined,
-      () => this.leaf.detach()
+      () => this.leaf.detach(),
+      () => { void this.app.workspace.requestSaveLayout(); },
+      (tab) => { void pushRecentSession(this.plugin, tab); }
     );
-    this.tabManager.createTab();
+
+    if (this.pendingState) {
+      // setState already fired (edge case) — apply its state
+      this.applyPendingState();
+    } else if (!parseSavedViewState(this.leaf.getViewState().state)) {
+      // No saved state incoming — create a default tab.
+      // (If saved state IS incoming, setState will fire next and own tab creation.)
+      this.tabManager.createTab();
+    }
 
     // Resize observer for auto-fit
     this.resizeObserver = new ResizeObserver(() => {
@@ -74,6 +91,18 @@ export class TerminalView extends ItemView {
       }, 50);
     });
     this.resizeObserver.observe(terminalHostEl);
+
+    // Periodic save: every 10s, if terminal output happened since the last check,
+    // trigger requestSaveLayout. This replaces per-chunk save calls that caused
+    // input lag under heavy output (e.g. Claude streaming). Quit still flushes
+    // via main.ts's workspace.on("quit") → requestSaveLayout.run().
+    this.registerInterval(
+      window.setInterval(() => {
+        if (this.tabManager?.consumeOutputDirty()) {
+          void this.app.workspace.requestSaveLayout();
+        }
+      }, 10000)
+    );
   }
 
   // eslint-disable-next-line @typescript-eslint/require-await -- onClose must satisfy Promise<void> return type of parent ItemView; no actual async work here
@@ -95,4 +124,68 @@ export class TerminalView extends ItemView {
   updateBackgroundColor(): void {
     this.tabManager?.updateBackgroundColor();
   }
+
+  getState(): Record<string, unknown> {
+    if (!this.tabManager) {
+      // Before onOpen runs (or after onClose): hand back any pending state we still have
+      return this.pendingState
+        ? { tabs: this.pendingState.tabs, activeIndex: this.pendingState.activeIndex }
+        : {};
+    }
+    const state: SavedViewState = {
+      tabs: this.tabManager.serializeSessions(),
+      activeIndex: this.tabManager.getActiveIndex(),
+    };
+    return { ...state };
+  }
+
+  // eslint-disable-next-line @typescript-eslint/require-await -- async required by parent View.setState signature; restore is synchronous
+  async setState(state: unknown, result: ViewStateResult): Promise<void> {
+    result.history = false;
+    const parsed = parseSavedViewState(state);
+    if (!parsed) return;
+
+    this.pendingState = parsed;
+    if (!this.tabManager) return;
+
+    // setState is authoritative: if any tabs exist (e.g. a default tab created
+    // by onOpen before the getViewState peek detected incoming state), replace them.
+    // Pass saveToRecents=false — the default tab had no user activity.
+    if (this.tabManager.getSessions().length > 0) {
+      this.tabManager.destroyAll(false);
+    }
+    this.applyPendingState();
+  }
+
+  private applyPendingState(): void {
+    const state = this.pendingState;
+    if (!state || !this.tabManager) return;
+    this.pendingState = null;
+
+    for (const tab of state.tabs) {
+      this.tabManager.createTab({
+        name: tab.name,
+        color: tab.color,
+        cwd: tab.cwd,
+        bufferSerial: tab.bufferSerial,
+        resumeCommand: tab.resumeCommand,
+      });
+    }
+
+    if (state.activeIndex >= 0) {
+      this.tabManager.switchToIndex(state.activeIndex);
+    }
+  }
+}
+
+/**
+ * Validate and narrow an unknown state value to SavedViewState.
+ * Returns null for missing, malformed, or empty state.
+ */
+function parseSavedViewState(state: unknown): SavedViewState | null {
+  if (!state || typeof state !== "object") return null;
+  const s = state as Partial<SavedViewState>;
+  if (!Array.isArray(s.tabs) || s.tabs.length === 0) return null;
+  const activeIndex = typeof s.activeIndex === "number" ? s.activeIndex : 0;
+  return { tabs: s.tabs, activeIndex };
 }


### PR DESCRIPTION
## Summary

Three related capabilities built on Obsidian's View state lifecycle:

1. **Session persistence** (always on) — tabs, names, colors, cwd, and scrollback buffer restored when Obsidian reopens, via `getState`/`setState` and `@xterm/addon-serialize`
2. **Recent sessions rescue** — ring buffer of the last *N* closed tabs; **Restore recent terminal session** command opens a fuzzy picker
3. **Claude Code integration** (opt-in, default off) — scans `~/.claude/projects/` for conversations in the current vault, generates a markdown registry note with clickable Resume links, and registers `obsidian://lean-terminal?resume=<uuid>` so clicking a link opens a new tab and auto-runs `claude --resume <uuid>`

## Why

- Closing Obsidian wipes all terminal state; accidental X on a tab is unrecoverable
- Claude Code users need a way to jump back into specific conversations without memorizing UUIDs or running `/resume` inside the CLI

## New settings

| Setting | Default | Purpose |
|---------|---------|---------|
| Persist terminal buffer | On | Save scrollback across restarts |
| Recent sessions to keep | 10 | Rescue buffer size; 0 disables |
| Enable Claude Code integration | Off | Master toggle — reveals the two below |
| Registry note path | `claude-sessions.md` | Where to write the registry |
| Registry sessions to keep | 25 | Max entries in the registry/picker |

## New commands

- **Restore recent terminal session** (always available)
- **Refresh Claude session registry** (gated on Claude integration)

## Design highlights

- `requestSaveLayout` is debounced by Obsidian; a periodic 10s timer consumes a "dirty" flag instead of firing on every terminal write, and `workspace.on('quit')` calls `requestSaveLayout.run()` to flush pending saves on shutdown
- `openTabOrView` uses destroy-and-recreate instead of `setViewState`-with-state, so transient `CreateTabOpts` fields survive (race guard in `createTab` prevents the defaulted tab's `setTimeout` from spawning a zombie PTY)
- Auto-resume uses `terminal.parser.registerOscHandler(133)` watching for "A" (prompt start from shell integration) with a 2s fallback timer
- Claude slash-command markup (`<command-name>/foo</command-name>`) is stripped from first-prompt text in the registry

## Known limitations

- Shell processes don't survive quit (visual/history restore, not process handoff)
- A `claude` session started by typing it in the shell is not auto-tracked on restart, but it appears in the restore picker (fresh scan each open) — one click to resume
- `cwd` is captured at tab-creation time; OSC 7 tracking would be a natural follow-up

## Files

- 4 new source files (`session-state.ts`, `terminal-opener.ts`, `claude-sessions.ts`, `recent-sessions.ts`)
- 4 modified source files (`main.ts`, `terminal-view.ts`, `terminal-tab-manager.ts`, `settings.ts`)
- 1 new dep: `@xterm/addon-serialize@^0.13.0`
- README updated

## Testing

Manually exercised on Windows 11 + PowerShell 7 in Obsidian 1.7.x. All pre-existing commands and settings unchanged. `npm run build` passes (tsc + esbuild).

---

No version bump — leaving release management to the maintainer.