### PR TITLE
feat: optional wiki-link autocomplete with path-insertion modes

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,22 @@
+lean-obsidian-terminal
+======================
+
+This project incorporates the wiki-link autocomplete feature adapted from
+internetvin/internetvin-terminal:
+
+    https://github.com/internetvin/internetvin-terminal
+    MIT License
+    Copyright (c) 2025 Vin Verma
+
+The port lives in src/wikilink-autocomplete.ts, with cooperative hooks added
+in src/terminal-tab-manager.ts and supporting CSS appended to styles.css
+(class names renamed from `.vin-*` to `.lean-*`).
+
+Adaptations applied while porting:
+  - Strict null checks / `noImplicitAny` compliance
+  - `as any` removed; replaced with typed `MetadataCacheInternal` view
+  - `isActive()` accessor + explicit `dispose()` added for lean's
+    session-lifecycle contract
+  - `handleKey()` composition with lean's existing custom key-event handler
+  - Unresolved-link and frontmatter-tag handling hardened against string |
+    string[] | undefined shapes

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -3,6 +3,15 @@ import type TerminalPlugin from "./main";
 
 export type NotificationSound = "beep" | "chime" | "ping" | "pop";
 
+/**
+ * How an accepted wiki-link suggestion is written to the shell.
+ * - "wikilink": classic `[[Note Name]]` (default, vault-friendly).
+ * - "vault-path": vault-relative path (`Folder/Note.md`) — for tools that resolve from the vault root.
+ * - "absolute-path": absolute filesystem path — useful when piping to CLI tools (Claude Code,
+ *   ripgrep, cat, etc.) that expect a real file path argument rather than a wikilink.
+ */
+export type WikiLinkInsertMode = "wikilink" | "vault-path" | "absolute-path";
+
 export interface TerminalPluginSettings {
   shellPath: string;
   fontSize: number;
@@ -18,6 +27,8 @@ export interface TerminalPluginSettings {
   notificationSound: NotificationSound;
   notificationVolume: number;
   searchShortcut: string;
+  wikiLinkAutocomplete: boolean;
+  wikiLinkInsertMode: WikiLinkInsertMode;
 }
 
 export const DEFAULT_SETTINGS: TerminalPluginSettings = {
@@ -35,6 +46,8 @@ export const DEFAULT_SETTINGS: TerminalPluginSettings = {
   notificationSound: "beep",
   notificationVolume: 50,
   searchShortcut: "Ctrl+Alt+F",
+  wikiLinkAutocomplete: false,
+  wikiLinkInsertMode: "wikilink",
 };
 
 export class TerminalSettingTab extends PluginSettingTab {
@@ -316,6 +329,34 @@ export class TerminalSettingTab extends PluginSettingTab {
           this.plugin.updateCopyOnSelect();
         })
       );
+
+    new Setting(containerEl)
+      .setName("Wiki-link autocomplete")
+      .setDesc(
+        "Type [[ in the terminal to open a dropdown of vault notes. Applies to newly opened tabs.",
+      )
+      .addToggle((toggle) =>
+        toggle.setValue(this.plugin.settings.wikiLinkAutocomplete).onChange(async (value) => {
+          this.plugin.settings.wikiLinkAutocomplete = value;
+          await this.plugin.saveSettings();
+        }),
+      );
+
+    new Setting(containerEl)
+      .setName("Wiki-link insertion format")
+      .setDesc(
+        "What to write when you accept a suggestion. Use a path mode to hand off to CLI tools (Claude Code, ripgrep, cat) that expect a file path instead of [[Note]].",
+      )
+      .addDropdown((dropdown) => {
+        dropdown.addOption("wikilink", "Wiki-link ([[Note]])");
+        dropdown.addOption("vault-path", "Vault-relative path (Folder/Note.md)");
+        dropdown.addOption("absolute-path", "Absolute path");
+        dropdown.setValue(this.plugin.settings.wikiLinkInsertMode);
+        dropdown.onChange(async (value: string) => {
+          this.plugin.settings.wikiLinkInsertMode = value as WikiLinkInsertMode;
+          await this.plugin.saveSettings();
+        });
+      });
 
     new Setting(containerEl)
       .setName("Scrollback lines")

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -6,8 +6,8 @@ export type NotificationSound = "beep" | "chime" | "ping" | "pop";
 /**
  * How an accepted wiki-link suggestion is written to the shell.
  * - "wikilink": classic `[[Note Name]]` (default, vault-friendly).
- * - "vault-path": vault-relative path (`Folder/Note.md`) — for tools that resolve from the vault root.
- * - "absolute-path": absolute filesystem path — useful when piping to CLI tools (Claude Code,
+ * - "vault-path": vault-relative path (`Folder/Note.md`), for tools that resolve from the vault root.
+ * - "absolute-path": absolute filesystem path. Useful when piping to CLI tools (Claude Code,
  *   ripgrep, cat, etc.) that expect a real file path argument rather than a wikilink.
  */
 export type WikiLinkInsertMode = "wikilink" | "vault-path" | "absolute-path";

--- a/src/terminal-tab-manager.ts
+++ b/src/terminal-tab-manager.ts
@@ -11,6 +11,7 @@ import type { TerminalPluginSettings } from "./settings";
 import type { NotificationSound } from "./settings";
 import type { BinaryManager } from "./binary-manager";
 import type { IDisposable } from "@xterm/xterm";
+import { WikiLinkAutocomplete, type AutocompleteEntry } from "./wikilink-autocomplete";
 
 const SEARCH_DECORATIONS = {
   matchBackground: "#ffff00",
@@ -82,6 +83,7 @@ export interface TerminalSession {
   overlayEl: HTMLElement;
   toggleSearch: () => void;
   pinned: boolean;
+  autocomplete: WikiLinkAutocomplete | null;
 }
 
 let sessionCounter = 0;
@@ -491,6 +493,10 @@ export class TerminalTabManager {
 
     // Intercept clipboard shortcuts — Obsidian captures them before xterm.js
     terminal.attachCustomKeyEventHandler((e: KeyboardEvent) => {
+      // Wiki-link autocomplete swallows navigation keys while its dropdown is open.
+      const s = this.sessions.find((s) => s.id === id);
+      if (s?.autocomplete?.handleKey(e)) return false;
+
       if (e.type !== "keydown") return true;
       const mod = e.metaKey || e.ctrlKey;
 
@@ -533,6 +539,40 @@ export class TerminalTabManager {
     });
 
     const pty = new PtyManager(this.pluginDir);
+
+    // Resolves the string written to the PTY when the user accepts a suggestion.
+    // The two `[[` chars were already echoed (autocomplete observes data, never
+    // consumes), so path modes prepend two DEL chars to erase them before
+    // writing the resolved path.
+    const ERASE_BRACKETS = "\x7f\x7f";
+    const resolveInsertion = (entry: AutocompleteEntry | null, query: string): string => {
+      const mode = this.settings.wikiLinkInsertMode;
+      if (entry?.isFile && (mode === "vault-path" || mode === "absolute-path")) {
+        const vaultPath = entry.folder ? `${entry.folder}/${entry.name}.md` : `${entry.name}.md`;
+        if (mode === "vault-path") {
+          return `${ERASE_BRACKETS}${quotePath(vaultPath, pty.shellPath)}`;
+        }
+        const adapter = this.app.vault.adapter as FileSystemAdapter;
+        const path = window.require("path") as { join: (...parts: string[]) => string; sep: string };
+        const abs = path.join(adapter.getBasePath(), vaultPath.split("/").join(path.sep));
+        return `${ERASE_BRACKETS}${quotePath(abs, pty.shellPath)}`;
+      }
+      // Wiki-link mode (default) and unresolved/empty fallbacks.
+      if (entry) return `${entry.name}]]`;
+      if (query.length > 0) return `${query}]]`;
+      return "]]";
+    };
+
+    const autocomplete = this.settings.wikiLinkAutocomplete
+      ? new WikiLinkAutocomplete(
+          this.app,
+          terminal,
+          (d: string) => pty.write(d),
+          containerEl,
+          resolveInsertion,
+        )
+      : null;
+
     const session: TerminalSession = {
       id, name, terminal, fitAddon, pty, containerEl, color: "",
       mode2031: false,
@@ -542,6 +582,7 @@ export class TerminalTabManager {
       overlayEl,
       toggleSearch,
       pinned: false,
+      autocomplete,
     };
 
     // Register terminal color reporting (OSC 10/11, Mode 2031)
@@ -589,8 +630,9 @@ export class TerminalTabManager {
         terminal.write(data);
       });
 
-      // Wire data: xterm -> PTY
+      // Wire data: xterm -> PTY. Autocomplete observes but never consumes.
       terminal.onData((data: string) => {
+        session.autocomplete?.handleData(data);
         pty.write(data);
       });
 
@@ -635,6 +677,7 @@ export class TerminalTabManager {
     const session = this.sessions[idx];
     if (session.pinned) return;
 
+    session.autocomplete?.dispose();
     for (const d of session.parserDisposables) d.dispose();
     session.parserDisposables = [];
     session.pty.kill();

--- a/src/terminal-tab-manager.ts
+++ b/src/terminal-tab-manager.ts
@@ -547,14 +547,16 @@ export class TerminalTabManager {
     const ERASE_BRACKETS = "\x7f\x7f";
     const resolveInsertion = (entry: AutocompleteEntry | null, query: string): string => {
       const mode = this.settings.wikiLinkInsertMode;
-      if (entry?.isFile && (mode === "vault-path" || mode === "absolute-path")) {
-        const vaultPath = entry.folder ? `${entry.folder}/${entry.name}.md` : `${entry.name}.md`;
+      // entry.path holds the full vault-relative path with extension
+      // (e.g. "Folder/Note.md" or "Drawings/Sketch.canvas"). Path-mode
+      // insertion uses it directly so non-markdown notes work too.
+      if (entry?.isFile && entry.path && (mode === "vault-path" || mode === "absolute-path")) {
         if (mode === "vault-path") {
-          return `${ERASE_BRACKETS}${quotePath(vaultPath, pty.shellPath)}`;
+          return `${ERASE_BRACKETS}${quotePath(entry.path, pty.shellPath)}`;
         }
         const adapter = this.app.vault.adapter as FileSystemAdapter;
         const path = window.require("path") as { join: (...parts: string[]) => string; sep: string };
-        const abs = path.join(adapter.getBasePath(), vaultPath.split("/").join(path.sep));
+        const abs = path.join(adapter.getBasePath(), entry.path.split("/").join(path.sep));
         return `${ERASE_BRACKETS}${quotePath(abs, pty.shellPath)}`;
       }
       // Wiki-link mode (default) and unresolved/empty fallbacks.

--- a/src/wikilink-autocomplete.ts
+++ b/src/wikilink-autocomplete.ts
@@ -13,8 +13,16 @@ import { App, TFile } from "obsidian";
 import type { Terminal, IDisposable } from "@xterm/xterm";
 
 export interface AutocompleteEntry {
+  /** Display name (file basename, without extension). */
   name: string;
+  /** Display folder (parent path, "" for vault root). */
   folder: string;
+  /**
+   * Full vault-relative path including extension (e.g. `Folder/Note.md`,
+   * `Folder/Drawing.canvas`). Empty string for unresolved entries — they
+   * have no on-disk file yet, so path-mode insertion falls back to wikilink.
+   */
+  path: string;
   isFile: boolean;
   mtime: number;
 }
@@ -70,6 +78,10 @@ export class WikiLinkAutocomplete {
   private previewEl: HTMLElement | null = null;
   private filterTimer: ReturnType<typeof setTimeout> | null = null;
   private resizeDisposable: IDisposable | null = null;
+  /** Snapshot of vault entries taken on activate(); avoids O(#files) per keystroke. */
+  private cachedEntries: AutocompleteEntry[] | null = null;
+  /** Monotonic token; renderPreview discards results whose token is stale. */
+  private previewToken = 0;
 
   constructor(
     app: App,
@@ -127,7 +139,10 @@ export class WikiLinkAutocomplete {
    */
   handleKey(e: KeyboardEvent): boolean {
     if (!this.active) return false;
-    if (e.type !== "keydown") return true;
+    // Only consume keydown — keypress / keyup must flow through so IME
+    // composition and other host listeners keep working while the dropdown
+    // is open.
+    if (e.type !== "keydown") return false;
 
     switch (e.key) {
       case "ArrowUp":
@@ -165,8 +180,11 @@ export class WikiLinkAutocomplete {
           this.filterResults();
           return true;
         }
-        // Let mod-combos (Ctrl+V paste, etc.) fall through to the host handler.
-        return !(e.metaKey || e.ctrlKey);
+        // Let any mod-combo (Ctrl+V, Cmd+C, Alt+...) fall through to the host
+        // handler — including Alt-based shortcuts (e.g. Alt+Tab, terminal Alt
+        // chords). Only unmodified keystrokes that didn't match the named cases
+        // above are non-character (function keys, etc.) — also let those through.
+        return !(e.metaKey || e.ctrlKey || e.altKey);
     }
   }
 
@@ -187,6 +205,9 @@ export class WikiLinkAutocomplete {
     this.query = "";
     this.results = [];
     this.selectedIndex = 0;
+    // Refresh the entry cache on each activation so newly created notes
+    // appear without restarting the terminal session.
+    this.cachedEntries = null;
     this.filterResults();
   }
 
@@ -209,33 +230,45 @@ export class WikiLinkAutocomplete {
     this.query = "";
     this.results = [];
     this.selectedIndex = 0;
+    this.cachedEntries = null;
+    if (this.filterTimer) {
+      clearTimeout(this.filterTimer);
+      this.filterTimer = null;
+    }
     this.removeDropdown();
   }
 
+  /**
+   * Builds the full entry list from the vault. Files are deduped by full
+   * path (not basename) so notes with identical names in different folders
+   * both appear. Unresolved targets that don't already correspond to a
+   * file's basename are added with `isFile: false` and an empty path.
+   */
   private getAllEntries(): AutocompleteEntry[] {
     const entries: AutocompleteEntry[] = [];
-    const seen = new Set<string>();
+    const fileBasenames = new Set<string>();
 
     for (const f of this.app.vault.getFiles()) {
       entries.push({
         name: f.basename,
         folder: f.parent?.path ?? "",
+        path: f.path,
         isFile: true,
         mtime: f.stat.mtime,
       });
-      seen.add(f.basename.toLowerCase());
+      fileBasenames.add(f.basename.toLowerCase());
     }
 
     const internal = this.app.metadataCache as unknown as MetadataCacheInternal;
     const unresolved = internal.unresolvedLinks;
     if (unresolved) {
+      const seenUnresolved = new Set<string>();
       for (const sourceFile of Object.values(unresolved)) {
         for (const linkTarget of Object.keys(sourceFile)) {
           const key = linkTarget.toLowerCase();
-          if (!seen.has(key)) {
-            seen.add(key);
-            entries.push({ name: linkTarget, folder: "", isFile: false, mtime: 0 });
-          }
+          if (fileBasenames.has(key) || seenUnresolved.has(key)) continue;
+          seenUnresolved.add(key);
+          entries.push({ name: linkTarget, folder: "", path: "", isFile: false, mtime: 0 });
         }
       }
     }
@@ -246,8 +279,12 @@ export class WikiLinkAutocomplete {
   private filterResults(): void {
     if (this.filterTimer) clearTimeout(this.filterTimer);
     this.filterTimer = setTimeout(() => {
+      // Late timer fires after dismiss/accept could otherwise resurrect the dropdown.
+      if (!this.active) return;
       const q = this.query.toLowerCase();
-      const all = this.getAllEntries();
+      // Cache snapshot once per activation — avoids O(#files) per keystroke.
+      if (!this.cachedEntries) this.cachedEntries = this.getAllEntries();
+      const all = this.cachedEntries;
 
       if (q.length === 0) {
         this.results = [...all].sort((a, b) => b.mtime - a.mtime).slice(0, MAX_RESULTS);
@@ -354,25 +391,32 @@ export class WikiLinkAutocomplete {
 
   private async renderPreview(): Promise<void> {
     const entry = this.results[this.selectedIndex];
-    if (!entry || !entry.isFile) {
+    if (!entry || !entry.isFile || !entry.path) {
       this.removePreview();
       return;
     }
+
+    // Capture a token before any await; if selection changes while we're
+    // reading the file, a later renderPreview() will bump the token and
+    // we'll discard our stale result on resume.
+    const token = ++this.previewToken;
 
     if (!this.previewEl) {
       this.previewEl = this.containerEl.createDiv({ cls: "lean-wikilink-preview" });
     }
     this.positionPreview();
 
-    const path = entry.folder ? `${entry.folder}/${entry.name}.md` : `${entry.name}.md`;
-    const file = this.app.vault.getAbstractFileByPath(path);
+    const file = this.app.vault.getAbstractFileByPath(entry.path);
     if (!(file instanceof TFile)) {
+      if (token !== this.previewToken || !this.previewEl) return;
       this.previewEl.empty();
       this.previewEl.createDiv({ cls: "lean-preview-empty", text: "File not found" });
       return;
     }
 
     const content = await this.app.vault.cachedRead(file);
+    if (token !== this.previewToken || !this.previewEl) return;
+
     const preview = content.split("\n").slice(0, PREVIEW_LINES).join("\n");
 
     const cache = this.app.metadataCache.getFileCache(file);

--- a/src/wikilink-autocomplete.ts
+++ b/src/wikilink-autocomplete.ts
@@ -5,7 +5,7 @@
 // All keystrokes are intercepted at the xterm layer so the feature works
 // even inside TUIs (vim, claude-code, etc.).
 //
-// Ported from internetvin/internetvin-terminal (MIT © 2025 Vin Verma) — see NOTICE.
+// Ported from internetvin/internetvin-terminal (MIT (c) 2025 Vin Verma). See NOTICE.
 // Adapted for lean-obsidian-terminal: strict null checks, no `as any`,
 // explicit dispose(), isActive() accessor, renamed CSS hooks (`lean-`).
 
@@ -19,8 +19,8 @@ export interface AutocompleteEntry {
   folder: string;
   /**
    * Full vault-relative path including extension (e.g. `Folder/Note.md`,
-   * `Folder/Drawing.canvas`). Empty string for unresolved entries — they
-   * have no on-disk file yet, so path-mode insertion falls back to wikilink.
+   * `Folder/Drawing.canvas`). Empty string for unresolved entries (they
+   * have no on-disk file yet), so path-mode insertion falls back to wikilink.
    */
   path: string;
   isFile: boolean;
@@ -108,7 +108,7 @@ export class WikiLinkAutocomplete {
   /**
    * Call from the host's `terminal.onData` listener, before writing to the PTY.
    * Detects `[[` (consecutive or within a paste) and activates the dropdown.
-   * Never consumes data — the brackets still reach the shell so the user sees
+   * Never consumes data, the brackets still reach the shell so the user sees
    * their input echoed. The dropdown appears as an overlay.
    */
   handleData(data: string): void {
@@ -139,7 +139,7 @@ export class WikiLinkAutocomplete {
    */
   handleKey(e: KeyboardEvent): boolean {
     if (!this.active) return false;
-    // Only consume keydown — keypress / keyup must flow through so IME
+    // Only consume keydown. Keypress and keyup must flow through so IME
     // composition and other host listeners keep working while the dropdown
     // is open.
     if (e.type !== "keydown") return false;
@@ -181,9 +181,9 @@ export class WikiLinkAutocomplete {
           return true;
         }
         // Let any mod-combo (Ctrl+V, Cmd+C, Alt+...) fall through to the host
-        // handler — including Alt-based shortcuts (e.g. Alt+Tab, terminal Alt
+        // handler, including Alt-based shortcuts (e.g. Alt+Tab, terminal Alt
         // chords). Only unmodified keystrokes that didn't match the named cases
-        // above are non-character (function keys, etc.) — also let those through.
+        // above are non-character (function keys, etc.); also let those through.
         return !(e.metaKey || e.ctrlKey || e.altKey);
     }
   }
@@ -282,7 +282,7 @@ export class WikiLinkAutocomplete {
       // Late timer fires after dismiss/accept could otherwise resurrect the dropdown.
       if (!this.active) return;
       const q = this.query.toLowerCase();
-      // Cache snapshot once per activation — avoids O(#files) per keystroke.
+      // Cache snapshot once per activation, avoids O(#files) per keystroke.
       if (!this.cachedEntries) this.cachedEntries = this.getAllEntries();
       const all = this.cachedEntries;
 

--- a/src/wikilink-autocomplete.ts
+++ b/src/wikilink-autocomplete.ts
@@ -1,0 +1,439 @@
+// Wiki-link `[[` autocomplete for the terminal buffer.
+//
+// When the user types `[[` inside the terminal, an overlay dropdown appears
+// showing vault notes. Arrow keys / Tab / Enter select; Escape dismisses.
+// All keystrokes are intercepted at the xterm layer so the feature works
+// even inside TUIs (vim, claude-code, etc.).
+//
+// Ported from internetvin/internetvin-terminal (MIT © 2025 Vin Verma) — see NOTICE.
+// Adapted for lean-obsidian-terminal: strict null checks, no `as any`,
+// explicit dispose(), isActive() accessor, renamed CSS hooks (`lean-`).
+
+import { App, TFile } from "obsidian";
+import type { Terminal, IDisposable } from "@xterm/xterm";
+
+export interface AutocompleteEntry {
+  name: string;
+  folder: string;
+  isFile: boolean;
+  mtime: number;
+}
+
+/**
+ * Resolves the string written to the PTY when the user accepts a suggestion.
+ * Receives the selected entry (or null when none) and the query typed after `[[`.
+ * The host owns shell semantics (path resolution, quoting, brackets vs. path)
+ * so the autocomplete class stays UI-only.
+ */
+export type ResolveInsertion = (entry: AutocompleteEntry | null, query: string) => string;
+
+const defaultResolveInsertion: ResolveInsertion = (entry, query) => {
+  if (entry) return `${entry.name}]]`;
+  if (query.length > 0) return `${query}]]`;
+  return "]]";
+};
+
+interface UnresolvedLinksMap {
+  [sourceFile: string]: { [linkTarget: string]: number };
+}
+
+interface ResolvedLinksMap {
+  [sourceFile: string]: { [targetPath: string]: number };
+}
+
+interface MetadataCacheInternal {
+  unresolvedLinks?: UnresolvedLinksMap;
+  resolvedLinks?: ResolvedLinksMap;
+}
+
+const MAX_RESULTS = 10;
+const PREVIEW_LINES = 10;
+const PREVIEW_WIDTH = 280;
+const DROPDOWN_WIDTH = 300;
+const DROPDOWN_HEIGHT = 220;
+const FILTER_DEBOUNCE_MS = 16;
+
+export class WikiLinkAutocomplete {
+  private readonly app: App;
+  private readonly terminal: Terminal;
+  private readonly writeToShell: (data: string) => void;
+  private readonly containerEl: HTMLElement;
+  private readonly resolveInsertion: ResolveInsertion;
+
+  private active = false;
+  private query = "";
+  private results: AutocompleteEntry[] = [];
+  private selectedIndex = 0;
+  private lastCharWasBracket = false;
+
+  private dropdownEl: HTMLElement | null = null;
+  private previewEl: HTMLElement | null = null;
+  private filterTimer: ReturnType<typeof setTimeout> | null = null;
+  private resizeDisposable: IDisposable | null = null;
+
+  constructor(
+    app: App,
+    terminal: Terminal,
+    writeToShell: (data: string) => void,
+    containerEl: HTMLElement,
+    resolveInsertion: ResolveInsertion = defaultResolveInsertion,
+  ) {
+    this.app = app;
+    this.terminal = terminal;
+    this.writeToShell = writeToShell;
+    this.containerEl = containerEl;
+    this.resolveInsertion = resolveInsertion;
+
+    this.resizeDisposable = this.terminal.onResize(() => {
+      if (this.active && this.dropdownEl) this.positionDropdown();
+    });
+  }
+
+  isActive(): boolean {
+    return this.active;
+  }
+
+  /**
+   * Call from the host's `terminal.onData` listener, before writing to the PTY.
+   * Detects `[[` (consecutive or within a paste) and activates the dropdown.
+   * Never consumes data — the brackets still reach the shell so the user sees
+   * their input echoed. The dropdown appears as an overlay.
+   */
+  handleData(data: string): void {
+    if (this.active) return;
+
+    if (data.length > 1) {
+      if (data.includes("[[")) this.activate();
+      this.lastCharWasBracket = data.endsWith("[");
+      return;
+    }
+
+    if (data === "[") {
+      if (this.lastCharWasBracket) {
+        this.lastCharWasBracket = false;
+        this.activate();
+      } else {
+        this.lastCharWasBracket = true;
+      }
+    } else {
+      this.lastCharWasBracket = false;
+    }
+  }
+
+  /**
+   * Call from the host's `attachCustomKeyEventHandler` callback, before any
+   * other handling. Returns `true` when the key was consumed (host should
+   * `return false` from the xterm callback to suppress default behavior).
+   */
+  handleKey(e: KeyboardEvent): boolean {
+    if (!this.active) return false;
+    if (e.type !== "keydown") return true;
+
+    switch (e.key) {
+      case "ArrowUp":
+        e.preventDefault();
+        this.selectedIndex = Math.max(0, this.selectedIndex - 1);
+        this.renderDropdown();
+        return true;
+      case "ArrowDown":
+        e.preventDefault();
+        this.selectedIndex = Math.min(this.results.length - 1, this.selectedIndex + 1);
+        this.renderDropdown();
+        return true;
+      case "Enter":
+      case "Tab":
+        e.preventDefault();
+        this.accept();
+        return true;
+      case "Escape":
+        e.preventDefault();
+        this.dismiss();
+        return true;
+      case "Backspace":
+        e.preventDefault();
+        if (this.query.length > 0) {
+          this.query = this.query.slice(0, -1);
+          this.filterResults();
+        } else {
+          this.dismiss();
+        }
+        return true;
+      default:
+        if (e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
+          e.preventDefault();
+          this.query += e.key;
+          this.filterResults();
+          return true;
+        }
+        // Let mod-combos (Ctrl+V paste, etc.) fall through to the host handler.
+        return !(e.metaKey || e.ctrlKey);
+    }
+  }
+
+  dispose(): void {
+    if (this.filterTimer) {
+      clearTimeout(this.filterTimer);
+      this.filterTimer = null;
+    }
+    this.resizeDisposable?.dispose();
+    this.resizeDisposable = null;
+    this.removePreview();
+    this.removeDropdown();
+    this.active = false;
+  }
+
+  private activate(): void {
+    this.active = true;
+    this.query = "";
+    this.results = [];
+    this.selectedIndex = 0;
+    this.filterResults();
+  }
+
+  private accept(): void {
+    const entry =
+      this.results.length > 0 && this.selectedIndex < this.results.length
+        ? this.results[this.selectedIndex]
+        : null;
+    this.writeToShell(this.resolveInsertion(entry, this.query));
+    this.deactivate();
+  }
+
+  private dismiss(): void {
+    if (this.query.length > 0) this.writeToShell(this.query);
+    this.deactivate();
+  }
+
+  private deactivate(): void {
+    this.active = false;
+    this.query = "";
+    this.results = [];
+    this.selectedIndex = 0;
+    this.removeDropdown();
+  }
+
+  private getAllEntries(): AutocompleteEntry[] {
+    const entries: AutocompleteEntry[] = [];
+    const seen = new Set<string>();
+
+    for (const f of this.app.vault.getFiles()) {
+      entries.push({
+        name: f.basename,
+        folder: f.parent?.path ?? "",
+        isFile: true,
+        mtime: f.stat.mtime,
+      });
+      seen.add(f.basename.toLowerCase());
+    }
+
+    const internal = this.app.metadataCache as unknown as MetadataCacheInternal;
+    const unresolved = internal.unresolvedLinks;
+    if (unresolved) {
+      for (const sourceFile of Object.values(unresolved)) {
+        for (const linkTarget of Object.keys(sourceFile)) {
+          const key = linkTarget.toLowerCase();
+          if (!seen.has(key)) {
+            seen.add(key);
+            entries.push({ name: linkTarget, folder: "", isFile: false, mtime: 0 });
+          }
+        }
+      }
+    }
+
+    return entries;
+  }
+
+  private filterResults(): void {
+    if (this.filterTimer) clearTimeout(this.filterTimer);
+    this.filterTimer = setTimeout(() => {
+      const q = this.query.toLowerCase();
+      const all = this.getAllEntries();
+
+      if (q.length === 0) {
+        this.results = [...all].sort((a, b) => b.mtime - a.mtime).slice(0, MAX_RESULTS);
+      } else {
+        const prefix: AutocompleteEntry[] = [];
+        const contains: AutocompleteEntry[] = [];
+        for (const entry of all) {
+          const name = entry.name.toLowerCase();
+          if (name.startsWith(q)) prefix.push(entry);
+          else if (name.includes(q)) contains.push(entry);
+        }
+        this.results = [...prefix, ...contains].slice(0, MAX_RESULTS);
+      }
+
+      this.selectedIndex = Math.min(this.selectedIndex, Math.max(0, this.results.length - 1));
+      this.renderDropdown();
+    }, FILTER_DEBOUNCE_MS);
+  }
+
+  private renderDropdown(): void {
+    if (!this.dropdownEl) {
+      this.dropdownEl = this.containerEl.createDiv({ cls: "lean-wikilink-dropdown" });
+    }
+
+    this.positionDropdown();
+
+    this.dropdownEl.empty();
+    const header = this.dropdownEl.createDiv({ cls: "lean-wikilink-header" });
+    header.setText(`[[${this.query}`);
+
+    if (this.results.length === 0) {
+      this.dropdownEl.createDiv({ cls: "lean-wikilink-empty", text: "No matches" });
+    } else {
+      const list = this.dropdownEl.createDiv({ cls: "lean-wikilink-list" });
+      this.results.forEach((entry, i) => {
+        const itemClasses = ["lean-wikilink-item"];
+        if (i === this.selectedIndex) itemClasses.push("is-selected");
+        if (!entry.isFile) itemClasses.push("is-unresolved");
+        const item = list.createDiv({ cls: itemClasses.join(" ") });
+        item.dataset.index = String(i);
+        item.createSpan({ cls: "lean-wikilink-name", text: entry.name });
+
+        if (entry.isFile && entry.folder && entry.folder !== "/") {
+          item.createSpan({ cls: "lean-wikilink-path", text: entry.folder });
+        } else if (!entry.isFile) {
+          item.createSpan({ cls: "lean-wikilink-path", text: "no file yet" });
+        }
+
+        item.addEventListener("mousedown", (e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          this.selectedIndex = i;
+          this.accept();
+        });
+      });
+    }
+
+    void this.renderPreview();
+  }
+
+  private positionDropdown(): void {
+    if (!this.dropdownEl) return;
+
+    const buf = this.terminal.buffer.active;
+    const cursorX = buf.cursorX;
+    const cursorY = buf.cursorY;
+
+    const screen = this.containerEl.querySelector(".xterm-screen");
+    if (!screen) return;
+
+    const screenRect = screen.getBoundingClientRect();
+    const containerRect = this.containerEl.getBoundingClientRect();
+    const cellW = screenRect.width / this.terminal.cols;
+    const cellH = screenRect.height / this.terminal.rows;
+
+    const offsetX = screenRect.left - containerRect.left;
+    const offsetY = screenRect.top - containerRect.top;
+    const containerWidth = containerRect.width;
+    const containerHeight = containerRect.height;
+
+    let left = offsetX + cursorX * cellW;
+    if (left + DROPDOWN_WIDTH > containerWidth) {
+      left = Math.max(4, containerWidth - DROPDOWN_WIDTH - 4);
+    }
+
+    const cursorBottom = offsetY + (cursorY + 1) * cellH;
+    if ((containerHeight - cursorBottom) > DROPDOWN_HEIGHT || cursorY < this.terminal.rows / 2) {
+      this.dropdownEl.style.top = `${cursorBottom}px`;
+      this.dropdownEl.style.bottom = "";
+    } else {
+      this.dropdownEl.style.bottom = `${containerHeight - (offsetY + cursorY * cellH)}px`;
+      this.dropdownEl.style.top = "";
+    }
+    this.dropdownEl.style.left = `${left}px`;
+  }
+
+  private removeDropdown(): void {
+    this.removePreview();
+    if (this.dropdownEl) {
+      this.dropdownEl.remove();
+      this.dropdownEl = null;
+    }
+  }
+
+  private async renderPreview(): Promise<void> {
+    const entry = this.results[this.selectedIndex];
+    if (!entry || !entry.isFile) {
+      this.removePreview();
+      return;
+    }
+
+    if (!this.previewEl) {
+      this.previewEl = this.containerEl.createDiv({ cls: "lean-wikilink-preview" });
+    }
+    this.positionPreview();
+
+    const path = entry.folder ? `${entry.folder}/${entry.name}.md` : `${entry.name}.md`;
+    const file = this.app.vault.getAbstractFileByPath(path);
+    if (!(file instanceof TFile)) {
+      this.previewEl.empty();
+      this.previewEl.createDiv({ cls: "lean-preview-empty", text: "File not found" });
+      return;
+    }
+
+    const content = await this.app.vault.cachedRead(file);
+    const preview = content.split("\n").slice(0, PREVIEW_LINES).join("\n");
+
+    const cache = this.app.metadataCache.getFileCache(file);
+    const inlineTags = cache?.tags?.map((t) => t.tag) ?? [];
+    const fmTagsRaw = cache?.frontmatter?.tags;
+    const fmTags: string[] = Array.isArray(fmTagsRaw)
+      ? fmTagsRaw.map(String)
+      : typeof fmTagsRaw === "string"
+        ? [fmTagsRaw]
+        : [];
+    const allTags = Array.from(new Set<string>([...inlineTags, ...fmTags]));
+
+    const resolved = (this.app.metadataCache as unknown as MetadataCacheInternal).resolvedLinks ?? {};
+    let backlinkCount = 0;
+    for (const source of Object.keys(resolved)) {
+      if (resolved[source]?.[file.path]) backlinkCount++;
+    }
+
+    const dateStr = new Date(file.stat.mtime).toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+    });
+
+    this.previewEl.empty();
+    const meta = this.previewEl.createDiv({ cls: "lean-preview-meta" });
+    meta.createSpan({ cls: "lean-preview-date", text: dateStr });
+    meta.createSpan({
+      cls: "lean-preview-backlinks",
+      text: `${backlinkCount} backlink${backlinkCount !== 1 ? "s" : ""}`,
+    });
+
+    if (allTags.length > 0) {
+      const tagRow = this.previewEl.createDiv({ cls: "lean-preview-tags" });
+      for (const t of allTags) tagRow.createSpan({ cls: "lean-preview-tag", text: t });
+    }
+
+    this.previewEl.createDiv({ cls: "lean-preview-content", text: preview });
+  }
+
+  private positionPreview(): void {
+    if (!this.previewEl || !this.dropdownEl) return;
+
+    const dropRect = this.dropdownEl.getBoundingClientRect();
+    const containerRect = this.containerEl.getBoundingClientRect();
+    const rightSpace = containerRect.right - dropRect.right;
+
+    if (rightSpace >= PREVIEW_WIDTH) {
+      this.previewEl.style.left = `${dropRect.right - containerRect.left + 4}px`;
+    } else {
+      this.previewEl.style.left = `${dropRect.left - containerRect.left - PREVIEW_WIDTH - 4}px`;
+    }
+    this.previewEl.style.top = this.dropdownEl.style.top;
+    this.previewEl.style.bottom = this.dropdownEl.style.bottom;
+    this.previewEl.style.width = `${PREVIEW_WIDTH}px`;
+  }
+
+  private removePreview(): void {
+    if (this.previewEl) {
+      this.previewEl.remove();
+      this.previewEl = null;
+    }
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -473,3 +473,132 @@
   opacity: 0.8;
   flex-shrink: 0;
 }
+
+/* --- Wiki-link autocomplete dropdown --------------------------------- */
+.lean-wikilink-dropdown {
+  position: absolute;
+  z-index: 100;
+  min-width: 260px;
+  max-width: 420px;
+  max-height: 240px;
+  background: var(--background-secondary);
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 10px;
+  font-family: var(--font-interface);
+  font-size: 12.5px;
+  color: var(--text-normal);
+  overflow: hidden;
+  box-shadow: var(--shadow-s);
+}
+
+.lean-wikilink-header {
+  padding: 8px 12px;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-muted);
+  border-bottom: 1px solid var(--background-modifier-border);
+}
+
+.lean-wikilink-empty {
+  padding: 12px;
+  color: var(--text-faint);
+  font-style: italic;
+}
+
+.lean-wikilink-list {
+  overflow-y: auto;
+  max-height: 200px;
+}
+
+.lean-wikilink-item {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  padding: 7px 12px;
+  cursor: pointer;
+  transition: background 0.1s;
+}
+
+.lean-wikilink-item:hover {
+  background: var(--background-modifier-hover);
+}
+
+.lean-wikilink-item.is-selected {
+  background: rgba(var(--interactive-accent-rgb, 0, 122, 255), 0.1);
+}
+
+.lean-wikilink-name {
+  color: var(--text-normal);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.lean-wikilink-path {
+  color: var(--text-faint);
+  font-size: 10.5px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  margin-left: auto;
+}
+
+.lean-wikilink-item.is-unresolved .lean-wikilink-name {
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+/* --- Wiki-link preview pane ------------------------------------------ */
+.lean-wikilink-preview {
+  position: absolute;
+  background: var(--background-secondary);
+  border: 1px solid var(--background-modifier-border);
+  border-radius: 10px;
+  padding: 12px;
+  font-size: 12px;
+  color: var(--text-normal);
+  max-height: 240px;
+  overflow: hidden;
+  z-index: 1001;
+  font-family: var(--font-interface);
+  box-shadow: var(--shadow-s);
+}
+
+.lean-preview-meta {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 8px;
+  font-size: 10.5px;
+  color: var(--text-muted);
+}
+
+.lean-preview-backlinks { color: var(--text-accent); }
+
+.lean-preview-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-bottom: 8px;
+}
+
+.lean-preview-tag {
+  background: var(--background-primary-alt);
+  padding: 2px 7px;
+  border-radius: 4px;
+  font-size: 10.5px;
+  color: var(--text-accent);
+}
+
+.lean-preview-content {
+  white-space: pre-wrap;
+  word-break: break-word;
+  line-height: 1.55;
+  color: var(--text-muted);
+  max-height: 150px;
+  overflow: hidden;
+}
+
+.lean-preview-empty {
+  color: var(--text-faint);
+  font-style: italic;
+}


### PR DESCRIPTION
## Summary
Adds an opt-in `[[`-triggered autocomplete dropdown to the terminal, listing vault notes (recents + filtered by query) with a side preview pane (backlinks, tags, first ~10 lines). Three insertion formats are exposed in settings:

- **Wiki-link** (default): writes `[[Note]]`
- **Vault-relative path**: writes `Folder/Note.md`
- **Absolute path**: writes the on-disk path, quoted via the existing `quotePath()` helper used by drag-and-drop file-path insertion

The path modes target users running TUI tools inside the terminal (Claude Code, ripgrep, cat) that want a real file argument instead of a wikilink.

## Defaults
Both knobs are opt-in / vault-friendly so this PR does not change behavior for existing users:

- `wikiLinkAutocomplete: false` — opt-in, so the `[[` interception does not surprise users running TUIs that need raw bracket input
- `wikiLinkInsertMode: "wikilink"` — vault-friendly default

## Attribution
The autocomplete class in `src/wikilink-autocomplete.ts` is adapted from [internetvin/internetvin-terminal](https://github.com/internetvin/internetvin-terminal) (MIT (c) 2025 Vin Verma). See `NOTICE` for the full text. Adaptations: strict null checks, `as any` removed (replaced with a typed `MetadataCacheInternal` view), explicit `dispose()` / `isActive()`, lean's `lean-*` CSS class names, hardened handling of `string | string[] | undefined` shapes for unresolved-link and frontmatter-tag data.

## Implementation notes
- `WikiLinkAutocomplete.handleData` is an observer on `terminal.onData` and never consumes data — the `[[` chars still echo to the PTY. Path modes prepend `\x7f\x7f` (DEL x 2) to erase them before writing the resolved path.
- `handleKey` composes with the existing `attachCustomKeyEventHandler`. It returns `true` only while the dropdown is active, so all other shortcuts (search, paste, copy, Shift+Enter) flow through unchanged. Modifier combos (Ctrl+V paste, etc.) intentionally fall through even with the dropdown open.
- A `resolveInsertion` callback in `terminal-tab-manager.ts` is the one place shell semantics live (path resolution + `quotePath` reuse). The autocomplete class itself stays UI-only — it doesn't know about modes, paths, or shells.
- `dispose()` is called from `closeTab()` so dropdown DOM and the resize listener don't leak when a tab closes.

## Test plan
- [x] Toggle ON -> type `[[` -> dropdown appears with recent notes
- [x] Arrow keys navigate; Tab/Enter accepts; Escape dismisses; Backspace narrows query
- [x] Switch to "Absolute path" -> accept -> terminal sees the on-disk path (Claude Code reads the file directly without any vault search)
- [x] Switch to "Vault-relative path" -> accept -> terminal sees `Folder/Note.md`
- [x] Toggle OFF -> `[[` typed in terminal passes through cleanly to TUI apps
- [x] Tested on Windows 11 / PowerShell 7 + Claude Code TUI
- [ ] Untested on macOS / Linux — review welcome