### PR TITLE
feat: per-tab color tint with editable palette

### DIFF
--- a/src/color-utils.ts
+++ b/src/color-utils.ts
@@ -1,0 +1,42 @@
+// Linear sRGB color mixing in JS. We need this because xterm.js's
+// `theme.background` is a solid color string (hex or rgb), not a CSS
+// expression, so `color-mix(...)` can't be used there.
+//
+// `mixHex("#1e1e1e", "#fc3634", 0.12)` → background tinted 12% toward tab color.
+
+function parseHex(hex: string): [number, number, number] | null {
+  const h = hex.trim().replace(/^#/, "");
+  if (h.length === 3) {
+    const r = parseInt(h[0] + h[0], 16);
+    const g = parseInt(h[1] + h[1], 16);
+    const b = parseInt(h[2] + h[2], 16);
+    if ([r, g, b].some(Number.isNaN)) return null;
+    return [r, g, b];
+  }
+  if (h.length === 6) {
+    const r = parseInt(h.slice(0, 2), 16);
+    const g = parseInt(h.slice(2, 4), 16);
+    const b = parseInt(h.slice(4, 6), 16);
+    if ([r, g, b].some(Number.isNaN)) return null;
+    return [r, g, b];
+  }
+  return null;
+}
+
+function toHex(v: number): string {
+  const clamped = Math.max(0, Math.min(255, Math.round(v)));
+  return clamped.toString(16).padStart(2, "0");
+}
+
+/**
+ * Mix `overlay` into `base` by `ratio` (0 = all base, 1 = all overlay).
+ * Returns a 6-digit hex string. If either input fails to parse, returns `base`.
+ */
+export function mixHex(base: string, overlay: string, ratio: number): string {
+  const b = parseHex(base);
+  const o = parseHex(overlay);
+  if (!b || !o) return base;
+  const r = Math.max(0, Math.min(1, ratio));
+  const mix = (i: 0 | 1 | 2): number => b[i] * (1 - r) + o[i] * r;
+  return `#${toHex(mix(0))}${toHex(mix(1))}${toHex(mix(2))}`;
+}

--- a/src/color-utils.ts
+++ b/src/color-utils.ts
@@ -1,8 +1,16 @@
-// Linear sRGB color mixing in JS. We need this because xterm.js's
-// `theme.background` is a solid color string (hex or rgb), not a CSS
-// expression, so `color-mix(...)` can't be used there.
+// Naive 8-bit sRGB channel mixing for terminal background tinting.
 //
-// `mixHex("#1e1e1e", "#fc3634", 0.12)` → background tinted 12% toward tab color.
+// We need this because xterm.js's `theme.background` is a solid color
+// string (only hex is parsed here), not a CSS expression, so `color-mix(...)`
+// can't be used at the xterm layer.
+//
+// Mixing happens in gamma-encoded sRGB (not sRGB-linear) since the
+// difference at the small tint ratios used here (typically <= 0.30) is
+// imperceptible and gamma decode/encode would add cost without visible
+// gain.
+//
+// `mixHex("#1e1e1e", "#fc3634", 0.12)` returns "#1e1e1e" tinted 12% toward
+// the tab color.
 
 function parseHex(hex: string): [number, number, number] | null {
   const h = hex.trim().replace(/^#/, "");

--- a/src/main.ts
+++ b/src/main.ts
@@ -149,6 +149,12 @@ export default class TerminalPlugin extends Plugin {
 
   async loadSettings(): Promise<void> {
     this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+    // tabColors is the only array in settings. Object.assign is shallow,
+    // so on a fresh install (data.json has no tabColors) the merged
+    // settings would share the reference with DEFAULT_SETTINGS, and any
+    // push/filter mutation would leak into the module-level default.
+    // Deep-clone here so the default array stays immutable.
+    this.settings.tabColors = this.settings.tabColors.map((c) => ({ ...c }));
   }
 
   async saveSettings(): Promise<void> {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,5 +1,11 @@
 import { App, ColorComponent, DropdownComponent, Notice, PluginSettingTab, Setting, setIcon } from "obsidian";
 import type TerminalPlugin from "./main";
+import {
+  DEFAULT_TAB_COLORS,
+  DEFAULT_TINT_STRENGTH,
+  MAX_TINT_STRENGTH,
+  type TabColorDef,
+} from "./tab-colors";
 
 export type NotificationSound = "beep" | "chime" | "ping" | "pop";
 
@@ -18,6 +24,8 @@ export interface TerminalPluginSettings {
   notificationSound: NotificationSound;
   notificationVolume: number;
   searchShortcut: string;
+  tabColorTintsBackground: boolean;
+  tabColors: TabColorDef[];
 }
 
 export const DEFAULT_SETTINGS: TerminalPluginSettings = {
@@ -35,14 +43,173 @@ export const DEFAULT_SETTINGS: TerminalPluginSettings = {
   notificationSound: "beep",
   notificationVolume: 50,
   searchShortcut: "Ctrl+Alt+F",
+  tabColorTintsBackground: true,
+  tabColors: DEFAULT_TAB_COLORS.map((c) => ({ ...c })),
 };
 
 export class TerminalSettingTab extends PluginSettingTab {
   plugin: TerminalPlugin;
+  private pendingNewColorName = "";
+  private pendingNewColorHex = "#888888";
 
   constructor(app: App, plugin: TerminalPlugin) {
     super(app, plugin);
     this.plugin = plugin;
+  }
+
+  private renderTabColorsSection(container: HTMLElement): void {
+    new Setting(container).setName("Tab colors").setHeading();
+
+    container.createDiv({
+      cls: "setting-item-description",
+      text:
+        "Palette shown in each tab's right-click menu. Built-in colors can be retuned but not deleted or renamed. Tint strength is per-color (0-" +
+        MAX_TINT_STRENGTH +
+        "%) so each color can be dialed to stay readable in the CLI it gets paired with.",
+    });
+
+    for (const color of this.plugin.settings.tabColors) {
+      if (!color.value) continue; // skip "None"
+      this.renderTabColorRow(container, color);
+    }
+
+    this.renderAddColorRow(container);
+
+    new Setting(container)
+      .addButton((btn) =>
+        btn
+          .setButtonText("Reset palette to defaults")
+          .setWarning()
+          .onClick(async () => {
+            this.plugin.settings.tabColors = DEFAULT_TAB_COLORS.map((c) => ({ ...c }));
+            await this.plugin.saveSettings();
+            this.plugin.updateTerminalBackgrounds();
+            this.display();
+          }),
+      );
+  }
+
+  private renderTabColorRow(container: HTMLElement, color: TabColorDef): void {
+    const row = new Setting(container);
+
+    const swatch = row.nameEl.createSpan({ cls: "lean-color-swatch" });
+    swatch.style.background = color.value;
+    row.nameEl.createSpan({ text: color.name });
+    row.setDesc(color.builtin ? `${color.value} - built-in` : color.value);
+
+    if (!color.builtin) {
+      row.addText((text) =>
+        text
+          .setPlaceholder("Name")
+          .setValue(color.name)
+          .onChange(async (value) => {
+            const trimmed = value.trim();
+            if (!trimmed) return;
+            if (
+              this.plugin.settings.tabColors.some((c) => c !== color && c.name === trimmed)
+            ) {
+              return;
+            }
+            color.name = trimmed;
+            await this.plugin.saveSettings();
+          }),
+      );
+
+      row.addColorPicker((picker) =>
+        picker.setValue(color.value).onChange(async (value) => {
+          color.value = value;
+          await this.plugin.saveSettings();
+          this.plugin.updateTerminalBackgrounds();
+          swatch.style.background = value;
+        }),
+      );
+    }
+
+    row.addSlider((slider) =>
+      slider
+        .setLimits(0, MAX_TINT_STRENGTH, 1)
+        .setValue(color.tintStrength)
+        .setDynamicTooltip()
+        .onChange(async (value) => {
+          color.tintStrength = value;
+          await this.plugin.saveSettings();
+          this.plugin.updateTerminalBackgrounds();
+        }),
+    );
+
+    if (color.builtin) {
+      row.addButton((btn) =>
+        btn
+          .setButtonText("Reset")
+          .setTooltip("Reset tint to default")
+          .onClick(async () => {
+            color.tintStrength = DEFAULT_TINT_STRENGTH;
+            await this.plugin.saveSettings();
+            this.plugin.updateTerminalBackgrounds();
+            this.display();
+          }),
+      );
+    } else {
+      row.addExtraButton((btn) =>
+        btn
+          .setIcon("trash")
+          .setTooltip("Delete color")
+          .onClick(async () => {
+            this.plugin.settings.tabColors = this.plugin.settings.tabColors.filter(
+              (c) => c !== color,
+            );
+            await this.plugin.saveSettings();
+            this.plugin.updateTerminalBackgrounds();
+            this.display();
+          }),
+      );
+    }
+  }
+
+  private renderAddColorRow(container: HTMLElement): void {
+    const setting = new Setting(container).setName("Add custom color");
+
+    setting.addText((text) =>
+      text
+        .setPlaceholder("Name")
+        .setValue(this.pendingNewColorName)
+        .onChange((value) => {
+          this.pendingNewColorName = value;
+        }),
+    );
+
+    setting.addColorPicker((picker) =>
+      picker.setValue(this.pendingNewColorHex).onChange((value) => {
+        this.pendingNewColorHex = value;
+      }),
+    );
+
+    setting.addButton((btn) =>
+      btn
+        .setButtonText("Add")
+        .setCta()
+        .onClick(async () => {
+          const name = this.pendingNewColorName.trim();
+          if (!name) {
+            new Notice("Color name is required.");
+            return;
+          }
+          if (this.plugin.settings.tabColors.some((c) => c.name === name)) {
+            new Notice("A color with that name already exists.");
+            return;
+          }
+          this.plugin.settings.tabColors.push({
+            name,
+            value: this.pendingNewColorHex,
+            tintStrength: DEFAULT_TINT_STRENGTH,
+            builtin: false,
+          });
+          this.pendingNewColorName = "";
+          this.pendingNewColorHex = "#888888";
+          await this.plugin.saveSettings();
+          this.display();
+        }),
+    );
   }
 
   display(): void {
@@ -296,6 +463,19 @@ export class TerminalSettingTab extends PluginSettingTab {
         this.plugin.updateTerminalBackgrounds();
       });
     });
+
+    new Setting(containerEl)
+      .setName("Tab color tints terminal background")
+      .setDesc("Mix a colored tab's swatch into the terminal background. Per-color tint strength is configured below.")
+      .addToggle((toggle) =>
+        toggle.setValue(this.plugin.settings.tabColorTintsBackground).onChange(async (value) => {
+          this.plugin.settings.tabColorTintsBackground = value;
+          await this.plugin.saveSettings();
+          this.plugin.updateTerminalBackgrounds();
+        }),
+      );
+
+    this.renderTabColorsSection(containerEl);
 
     new Setting(containerEl)
       .setName("Cursor blink")

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -63,7 +63,7 @@ export class TerminalSettingTab extends PluginSettingTab {
     container.createDiv({
       cls: "setting-item-description",
       text:
-        "Palette shown in each tab's right-click menu. Built-in colors can be retuned but not deleted or renamed. Tint strength is per-color (0-" +
+        "Palette shown in each tab's right-click menu. Built-in colors keep their name and hex, but their tint can be adjusted. Custom colors below can be fully edited (name, hex, tint) or deleted. Tint strength is per-color (0-" +
         MAX_TINT_STRENGTH +
         "%) so each color can be dialed to stay readable in the CLI it gets paired with.",
     });

--- a/src/tab-colors.ts
+++ b/src/tab-colors.ts
@@ -1,0 +1,34 @@
+// Tab color palette: built-in entries seeded on first run, plus any
+// user-defined colors added in Settings. Each entry carries its own tint
+// strength so users can dial the terminal-background mix per color
+// (e.g. softer red for CLIs with lots of red output).
+
+export interface TabColorDef {
+  name: string;
+  value: string;        // "" for the None entry, otherwise 6-digit hex
+  tintStrength: number; // percent, 0..30 (stored as a percent integer)
+  builtin: boolean;     // true = seeded preset, not deletable/renamable
+}
+
+export const DEFAULT_TAB_COLORS: TabColorDef[] = [
+  { name: "None",      value: "",        tintStrength: 0,  builtin: true },
+  { name: "Vermilion", value: "#FC3634", tintStrength: 12, builtin: true },
+  { name: "Sky Blue",  value: "#25D0F7", tintStrength: 12, builtin: true },
+  { name: "Gold",      value: "#FFD700", tintStrength: 12, builtin: true },
+  { name: "Mint",      value: "#18BC9C", tintStrength: 12, builtin: true },
+  { name: "Azure",     value: "#007BFF", tintStrength: 12, builtin: true },
+  { name: "Purple",    value: "#A991D4", tintStrength: 12, builtin: true },
+];
+
+export const MAX_TINT_STRENGTH = 30;
+export const DEFAULT_TINT_STRENGTH = 12;
+
+/** Look up the palette entry matching `hex`. Falls back to a synthetic
+ *  entry using the default tint strength when the session was colored with
+ *  a hex no longer present in the palette. */
+export function findTabColor(palette: TabColorDef[], hex: string): TabColorDef | null {
+  if (!hex) return null;
+  const match = palette.find((c) => c.value.toLowerCase() === hex.toLowerCase());
+  if (match) return match;
+  return { name: hex, value: hex, tintStrength: DEFAULT_TINT_STRENGTH, builtin: false };
+}

--- a/src/terminal-tab-manager.ts
+++ b/src/terminal-tab-manager.ts
@@ -11,6 +11,8 @@ import type { TerminalPluginSettings } from "./settings";
 import type { NotificationSound } from "./settings";
 import type { BinaryManager } from "./binary-manager";
 import type { IDisposable } from "@xterm/xterm";
+import { mixHex } from "./color-utils";
+import { findTabColor, DEFAULT_TINT_STRENGTH } from "./tab-colors";
 
 const SEARCH_DECORATIONS = {
   matchBackground: "#ffff00",
@@ -54,16 +56,6 @@ function matchesShortcut(e: KeyboardEvent, shortcut: string): boolean {
     e.key.toLowerCase() === p.key.toLowerCase()
   );
 }
-
-export const TAB_COLORS = [
-  { name: "None", value: "" },
-  { name: "Vermilion", value: "#FC3634" },
-  { name: "Sky Blue", value: "#25D0F7" },
-  { name: "Gold", value: "#FFD700" },
-  { name: "Mint", value: "#18BC9C" },
-  { name: "Azure", value: "#007BFF" },
-  { name: "Purple", value: "#A991D4" },
-] as const;
 
 export interface TerminalSession {
   id: string;
@@ -196,6 +188,27 @@ function resolveTerminalTheme(settings: TerminalPluginSettings, registry: ThemeR
   const theme = registry.get(settings.theme);
   if (settings.backgroundColor) {
     theme.background = settings.backgroundColor;
+  }
+  return theme;
+}
+
+/** Percent (0..MAX_TINT_STRENGTH) used to mix `color` into the terminal background. */
+function tintRatioForColor(color: string, settings: TerminalPluginSettings): number {
+  if (!color || !settings.tabColorTintsBackground) return 0;
+  const def = findTabColor(settings.tabColors, color);
+  return (def?.tintStrength ?? DEFAULT_TINT_STRENGTH) / 100;
+}
+
+/** Theme with the per-session tab color mixed into the background. */
+function resolveSessionTheme(
+  session: Pick<TerminalSession, "color">,
+  settings: TerminalPluginSettings,
+  registry: ThemeRegistry,
+) {
+  const theme = { ...resolveTerminalTheme(settings, registry) };
+  const ratio = tintRatioForColor(session.color, settings);
+  if (ratio > 0 && theme.background) {
+    theme.background = mixHex(theme.background, session.color, ratio);
   }
   return theme;
 }
@@ -770,7 +783,7 @@ export class TerminalTabManager {
     menu.createDiv({ cls: "terminal-ctx-item terminal-ctx-color-label", text: "Color" });
     const colorRow = menu.createDiv({ cls: "terminal-ctx-color-row" });
 
-    for (const c of TAB_COLORS) {
+    for (const c of this.settings.tabColors) {
       const swatch = colorRow.createDiv({ cls: "terminal-ctx-swatch" });
       if (c.value) {
         swatch.style.background = c.value;
@@ -783,6 +796,9 @@ export class TerminalTabManager {
       swatch.title = c.name;
       swatch.addEventListener("click", () => {
         session.color = c.value;
+        // Picking a new color reapplies the session theme so a tinted
+        // background reflects the new swatch immediately.
+        session.terminal.options.theme = resolveSessionTheme(session, this.settings, this.themeRegistry);
         this.renderTabBar();
         menu.remove();
       });
@@ -801,18 +817,16 @@ export class TerminalTabManager {
   }
 
   updateBackgroundColor(): void {
-    const theme = resolveTerminalTheme(this.settings, this.themeRegistry);
     for (const session of this.sessions) {
-      session.terminal.options.theme = theme;
+      session.terminal.options.theme = resolveSessionTheme(session, this.settings, this.themeRegistry);
     }
   }
 
   /** Re-apply the full theme to all sessions (used when Obsidian switches dark/light). */
   updateTheme(): void {
-    const theme = resolveTerminalTheme(this.settings, this.themeRegistry);
     const isDark = isObsidianDark();
     for (const session of this.sessions) {
-      session.terminal.options.theme = theme;
+      session.terminal.options.theme = resolveSessionTheme(session, this.settings, this.themeRegistry);
 
       // Notify child apps that opted into Mode 2031 color-scheme-change updates
       if (session.mode2031) {
@@ -830,14 +844,19 @@ export class TerminalTabManager {
     this.tabBarEl.empty();
 
     for (const session of this.sessions) {
-      const tab = this.tabBarEl.createDiv({
-        cls: `terminal-tab${session.id === this.activeId ? " active" : ""}${session.pinned ? " terminal-tab--pinned" : ""}`,
-      });
+      const classes = ["terminal-tab"];
+      if (session.id === this.activeId) classes.push("active");
+      if (session.pinned) classes.push("terminal-tab--pinned");
+      if (session.color) classes.push("terminal-tab--colored");
+      const tab = this.tabBarEl.createDiv({ cls: classes.join(" ") });
 
-      // Apply tab color as left border + active highlight
+      // Tab color drives two CSS variables. All visual rules (border + tinted
+      // fill across idle/hover/active states) live in styles.css so we don't
+      // hardcode opacity values here.
       if (session.color) {
-        tab.style.borderLeft = `3px solid ${session.color}`;
         tab.style.setProperty("--tab-accent", session.color);
+        const def = findTabColor(this.settings.tabColors, session.color);
+        tab.style.setProperty("--tab-color-intensity", String(def?.tintStrength ?? DEFAULT_TINT_STRENGTH));
       }
 
       if (session.pinned) {

--- a/src/terminal-tab-manager.ts
+++ b/src/terminal-tab-manager.ts
@@ -199,13 +199,15 @@ function tintRatioForColor(color: string, settings: TerminalPluginSettings): num
   return (def?.tintStrength ?? DEFAULT_TINT_STRENGTH) / 100;
 }
 
-/** Theme with the per-session tab color mixed into the background. */
+/** Theme with the per-session tab color mixed into the background.
+ *  resolveTerminalTheme already returns a fresh object (ThemeRegistry.get
+ *  clones), so we mutate its background in place rather than spreading again. */
 function resolveSessionTheme(
   session: Pick<TerminalSession, "color">,
   settings: TerminalPluginSettings,
   registry: ThemeRegistry,
 ) {
-  const theme = { ...resolveTerminalTheme(settings, registry) };
+  const theme = resolveTerminalTheme(settings, registry);
   const ratio = tintRatioForColor(session.color, settings);
   if (ratio > 0 && theme.background) {
     theme.background = mixHex(theme.background, session.color, ratio);

--- a/styles.css
+++ b/styles.css
@@ -473,3 +473,44 @@
   opacity: 0.8;
   flex-shrink: 0;
 }
+
+/* --- Per-tab colored fill ------------------------------------------- */
+/* --tab-accent (hex) and --tab-color-intensity (0..MAX, e.g. 12) come
+   from the tab-manager and drive idle/hover/active fill density. The
+   multiplier (1.5/2.2/2.7) lets users keep the same numeric intensity
+   value while idle/hover/active stay visually distinct. */
+.terminal-tab--colored {
+  background: color-mix(
+    in srgb,
+    var(--tab-accent) calc(var(--tab-color-intensity) * 1.5%),
+    transparent
+  );
+  border-left: 3px solid var(--tab-accent);
+}
+
+.terminal-tab--colored:hover {
+  background: color-mix(
+    in srgb,
+    var(--tab-accent) calc(var(--tab-color-intensity) * 2.2%),
+    var(--background-modifier-hover)
+  );
+}
+
+.terminal-tab--colored.active {
+  background: color-mix(
+    in srgb,
+    var(--tab-accent) calc(var(--tab-color-intensity) * 2.7%),
+    var(--background-primary)
+  );
+}
+
+/* Settings palette swatch chip */
+.lean-color-swatch {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border-radius: 3px;
+  margin-right: 8px;
+  vertical-align: middle;
+  border: 1px solid var(--background-modifier-border);
+}


### PR DESCRIPTION
## Summary

Replaces the hardcoded `TAB_COLORS` const with a user-editable palette stored in settings, and lets each color also tint the terminal background so the active CLI feels visually distinct from siblings without rebinding themes per-tab.

## Palette editor

Settings now has a "Tab colors" section. The seven existing colors are seeded as built-in entries (cannot be renamed or deleted, but their hex and tint strength can be retuned). Below them: add-custom-color form (name plus color picker), and a reset-palette-to-defaults button.

Per-color controls:
- Built-in: tint slider (0..30 percent) and reset-tint button
- Custom: name field, color picker, tint slider, delete button

## Background tint

A new toggle "Tab color tints terminal background" (default on) mixes the active tab's color into the terminal background. The mix percentage is driven by each color's individual `tintStrength` so users can dial it per color. A softer red for CLIs with lots of red output, a stronger purple for one that needs to stand out, etc.

JS mixing lives in `color-utils.ts` because xterm.js's `theme.background` is a solid color string (hex or rgb), not a CSS expression, so `color-mix()` cannot be used at the xterm layer.

## Tab bar fill

The previous inline `borderLeft` style is replaced by a `terminal-tab--colored` class plus two CSS variables (`--tab-accent`, `--tab-color-intensity`) so all visual rules (idle, hover, active) live in `styles.css` instead of being baked into `renderTabBar`. Active state uses `color-mix()` for a tinted fill that respects each color's intensity setting.

## Defaults

Preserve current behavior. The seven seeded colors match the existing `TAB_COLORS` (Vermilion, Sky Blue, Gold, Mint, Azure, Purple, plus None). `tabColorTintsBackground` defaults to true so users who set a tab color see immediate visual feedback. Existing users who upgrade get the same seeded palette via `Object.assign(DEFAULT_SETTINGS, ...)` in `loadSettings`.

## Files

- New: `src/color-utils.ts` (`mixHex` linear sRGB mixer, ~40 LOC)
- New: `src/tab-colors.ts` (`TabColorDef` type, `DEFAULT_TAB_COLORS`, `findTabColor`, tint constants)
- `src/settings.ts`: palette editor section, tints toggle, two new settings keys
- `src/terminal-tab-manager.ts`: drops the hardcoded `TAB_COLORS` const, adds `tintRatioForColor` and `resolveSessionTheme`, wires per-session theme into `updateBackgroundColor` / `updateTheme` / swatch click, sets CSS vars in `renderTabBar`
- `styles.css`: idle/hover/active fill rules using `color-mix()`, `.lean-color-swatch` chip for the settings rows

## Test plan

- [x] Reload Obsidian, settings shows new "Tab colors" section
- [x] Right-click tab, pick a color: tab fills tinted, terminal background gets a subtle tint
- [x] Drag the per-color slider: terminal background updates live across all sessions using that color
- [x] Toggle "Tab color tints terminal background" off: tab pill stays colored, terminal background reverts
- [x] Add custom color, delete it, reset palette to defaults
- [x] Restart Obsidian: palette persists
- [x] Tested on Windows 11 + PowerShell 7
- [ ] Untested on macOS / Linux