### PR TITLE
feat: add Windows ARM64 binary support for Snapdragon devices

### DIFF
--- a/.github/workflows/build-node-pty.yml
+++ b/.github/workflows/build-node-pty.yml
@@ -23,6 +23,9 @@ jobs:
           - os: windows-latest
             platform: win32
             arch: x64
+          - os: windows-arm64
+            platform: win32
+            arch: arm64
           - os: macos-15
             platform: darwin
             arch: arm64
@@ -33,6 +36,7 @@ jobs:
             platform: linux
             arch: x64
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 

--- a/README.md
+++ b/README.md
@@ -1,30 +1,27 @@
 # Lean Terminal
 
-An embedded terminal panel for [Obsidian](https://obsidian.md), powered by [xterm.js](https://xtermjs.org/) and [node-pty](https://github.com/nicedoc/node-pty). Run shell commands directly inside your vault workspace - no external windows needed.
+An embedded terminal panel for [Obsidian](https://obsidian.md), powered by [xterm.js](https://xtermjs.org/) and [node-pty](https://github.com/nicedoc/node-pty). Run shell commands directly inside your vault workspace — no external windows needed.
 
 **Desktop only.** Requires Obsidian 1.5.0+.
 
 ## Features
 
 - Full PTY terminal (not a simple command runner) with interactive shell support
-- Multiple terminal tabs with drag-to-reorder, rename, and color-coding support
+- Multiple terminal tabs with rename and color-coding support
 - Auto-detects your shell: PowerShell 7 / Windows PowerShell / cmd.exe on Windows, `$SHELL` on macOS/Linux
-- 12 built-in color schemes plus user-customizable themes via `themes.json`
-- System theme that follows Obsidian's dark/light mode automatically
-- Emoji and wide character rendering with correct Unicode 11 width tables
-- Drag a file from the Obsidian file explorer or Windows Explorer to insert its path into the terminal
+- Four built-in color themes: Obsidian Dark, Obsidian Light, Monokai, Solarized Dark
 - Customizable ribbon and panel tab icon (any Lucide icon name)
-- Clickable URLs in terminal output - Ctrl+click to open in your system browser
+- Clickable URLs in terminal output
 - Auto-resize on panel resize
 - Opens at vault root by default
-- Clipboard support: Ctrl+V / Cmd+V paste, Ctrl+C / Cmd+C copy (with selection), optional copy-on-select
-- Visible scrollbar in the terminal viewport for quick navigation
+- Clipboard support: Ctrl+V / Cmd+V paste, Ctrl+C / Cmd+C copy (with selection)
 - Notification sounds when background tab commands finish (4 sound types, adjustable volume)
 - Shift+Enter inserts a newline instead of submitting (muscle memory friendly for Claude Code users)
 - Custom background color override with color picker (match your vault theme)
-- In-terminal search with live match highlighting, forward/back navigation, case toggle, and configurable shortcut (default Ctrl+Alt+F)
-- Pin terminal tabs to prevent accidental closure - pinned tabs show a lock icon and block the close button
 - Configurable: shell path, font size, font family, cursor blink, scrollback, panel location
+- Session persistence: tabs, names, colors, working directories, and scrollback are restored when Obsidian reopens
+- Rescue recently closed tabs via command palette (ring buffer of the last 10 closed sessions by default)
+- Optional [Claude Code](https://claude.com/claude-code) integration: auto-maintained registry of sessions with clickable Resume links
 
 ## Installation
 
@@ -34,7 +31,7 @@ An embedded terminal panel for [Obsidian](https://obsidian.md), powered by [xter
 2. Open **Settings > BRAT > Add Beta Plugin**
 3. Enter: `sdkasper/lean-obsidian-terminal`
 4. Enable the plugin in **Settings > Community Plugins**
-5. Go to **Settings > Terminal > Download binaries** and click **Download** - this fetches the native terminal binary for your platform
+5. Go to **Settings > Terminal > Download binaries** and click **Download** — this fetches the native terminal binary for your platform
 6. Open the terminal via the ribbon icon or command palette
 
 ### Manual Installation
@@ -53,11 +50,9 @@ An embedded terminal panel for [Obsidian](https://obsidian.md), powered by [xter
 | New tab | Command palette: **New terminal tab**, or click the **+** button in the tab bar |
 | Rename tab | Right-click the tab label |
 | Close tab | Click the **x** on the tab |
-| Pin / Unpin tab | Right-click the tab label and choose **Pin** or **Unpin** |
-| Search scrollback | Press **Ctrl+Alt+F** (configurable) to open the search overlay |
-| Reorder tabs | Drag a tab header left or right within the tab bar |
-| Insert file path | Drag a file from the Obsidian file explorer or Windows Explorer and drop it into the terminal |
 | Split pane | Command palette: **Open terminal in new pane** |
+| Restore closed tab | Command palette: **Restore recent terminal session** — pick from recently closed tabs (and Claude sessions, if integration enabled) |
+| Refresh Claude session registry | Command palette: **Refresh Claude session registry** — rewrites the registry note (requires Claude integration enabled) |
 
 ## Settings
 
@@ -69,42 +64,40 @@ An embedded terminal panel for [Obsidian](https://obsidian.md), powered by [xter
 | Theme | Obsidian Dark | Color theme for the terminal |
 | Icon | terminal | Lucide icon name for the ribbon and panel tab icon |
 | Cursor blink | On | Whether the cursor blinks |
-| Copy on select | Off | Automatically copy selected text to the clipboard |
 | Scrollback | 5000 | Number of lines kept in scroll history |
 | Background color | Theme default | Override the theme background with any CSS color (hex, RGB, etc.) |
-| Default location | Bottom | Where the first terminal view opens |
+| Default location | Bottom | Where new terminal panels open (Bottom or Right) |
 | Notify on completion | Off | Sound + notice when a background tab command finishes |
 | Notification sound | Beep | Choose from Beep, Chime, Ping, or Pop |
-| Notification volume | 50 | Volume for notification sounds (0-100) |
-| Search shortcut | Ctrl+Alt+F | Keyboard shortcut to open the in-terminal search overlay |
-
-## Custom themes
-
-The plugin ships with 12 built-in color schemes selectable from **Settings → Appearance & behavior → Theme**. You can add your own by editing `themes.json` in the plugin folder (`<vault>/.obsidian/plugins/lean-terminal/themes.json`).
-
-Use **Open themes folder** in settings to jump straight to it. The file is a plain JSON object keyed by theme name; user themes override built-ins of the same name.
-
-Minimal example:
-
-```json
-{
-  "my-dark": {
-    "background": "#101010",
-    "foreground": "#e0e0e0",
-    "cursor": "#ffffff"
-  }
-}
-```
-
-`background` and `foreground` are required; all other xterm `ITheme` fields (`cursor`, `black`, `red`, `green`, … `brightWhite`) are optional - omitted fields use xterm defaults. Colors must be 6-digit hex (`#rrggbb`).
-
-After editing, click **Reload themes** in settings to apply without restarting Obsidian.
+| Notification volume | 50 | Volume for notification sounds (0–100) |
+| Persist terminal buffer | On | Save scrollback history across restarts. Disable to reduce workspace.json size |
+| Recent sessions to keep | 10 | Closed-tab rescue buffer size. Set to 0 to disable |
+| Enable Claude Code integration | Off | Scan `~/.claude/` for sessions, register the `obsidian://lean-terminal` URI handler, include Claude sessions in the restore picker |
+| Registry note path | claude-sessions.md | Vault-relative path to the auto-maintained Claude sessions registry |
+| Registry sessions to keep | 25 | Max Claude sessions listed in the registry note and picker |
 
 ## How It Works
 
 The plugin uses xterm.js for terminal rendering and node-pty for native pseudo-terminal support. node-pty spawns a real shell process (PowerShell, bash, etc.) and connects its stdin/stdout to xterm.js via Obsidian's Electron runtime. This gives you a fully interactive terminal — not just command execution.
 
-On Windows, the plugin uses ConPTY (via a patched ConoutConnection that avoids Worker threads, which Obsidian's Electron renderer does not support). This gives correct UTF-8 and emoji handling on Windows.
+On Windows, the plugin uses the winpty backend because Obsidian's Electron renderer does not support Worker threads required by ConPTY.
+
+## Session Persistence
+
+Each terminal tab's name, color, working directory, and scrollback buffer are saved to the workspace layout on close and on Obsidian quit. On next launch, tabs are restored with their history visible and a fresh shell spawned in the saved directory. This is visual/history restore — the underlying shell process does not survive quit.
+
+Closing a tab (**x** button) pushes its state to a rescue ring buffer stored in plugin data. Use **Restore recent terminal session** from the command palette to re-open a closed tab at any point.
+
+## Claude Code Integration
+
+Disabled by default. When enabled in settings, the plugin:
+
+- Scans `~/.claude/projects/` for conversation sessions associated with the current vault
+- Generates a markdown registry note on demand (**Refresh Claude session registry** command) with clickable Resume links
+- Registers the `obsidian://lean-terminal?resume=<session-id>` URI so links in the registry (or any note) open a new terminal tab and run `claude --resume <session-id>` once the shell is ready
+- Includes Claude sessions alongside recently closed tabs in the **Restore recent terminal session** picker, sorted by most recent
+
+Sessions started by typing `claude` manually inside a tab are not auto-tracked, but appear in the picker on its next open (the scan runs fresh each time) — click to resume.
 
 ## Feedback
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Lean Terminal
 
-An embedded terminal panel for [Obsidian](https://obsidian.md), powered by [xterm.js](https://xtermjs.org/) and [node-pty](https://github.com/nicedoc/node-pty). Run shell commands directly inside your vault workspace — no external windows needed.
+An embedded terminal panel for [Obsidian](https://obsidian.md), powered by [xterm.js](https://xtermjs.org/) and [node-pty](https://github.com/nicedoc/node-pty). Run shell commands directly inside your vault workspace - no external windows needed.
 
 **Desktop only.** Requires Obsidian 1.5.0+.
 
@@ -31,7 +31,7 @@ An embedded terminal panel for [Obsidian](https://obsidian.md), powered by [xter
 2. Open **Settings > BRAT > Add Beta Plugin**
 3. Enter: `sdkasper/lean-obsidian-terminal`
 4. Enable the plugin in **Settings > Community Plugins**
-5. Go to **Settings > Terminal > Download binaries** and click **Download** — this fetches the native terminal binary for your platform
+5. Go to **Settings > Terminal > Download binaries** and click **Download** - this fetches the native terminal binary for your platform
 6. Open the terminal via the ribbon icon or command palette
 
 ### Manual Installation
@@ -51,8 +51,8 @@ An embedded terminal panel for [Obsidian](https://obsidian.md), powered by [xter
 | Rename tab | Right-click the tab label |
 | Close tab | Click the **x** on the tab |
 | Split pane | Command palette: **Open terminal in new pane** |
-| Restore closed tab | Command palette: **Restore recent terminal session** — pick from recently closed tabs (and Claude sessions, if integration enabled) |
-| Refresh Claude session registry | Command palette: **Refresh Claude session registry** — rewrites the registry note (requires Claude integration enabled) |
+| Restore closed tab | Command palette: **Restore recent terminal session** - pick from recently closed tabs (and Claude sessions, if integration enabled) |
+| Refresh Claude session registry | Command palette: **Refresh Claude session registry** - rewrites the registry note (requires Claude integration enabled) |
 
 ## Settings
 
@@ -78,13 +78,13 @@ An embedded terminal panel for [Obsidian](https://obsidian.md), powered by [xter
 
 ## How It Works
 
-The plugin uses xterm.js for terminal rendering and node-pty for native pseudo-terminal support. node-pty spawns a real shell process (PowerShell, bash, etc.) and connects its stdin/stdout to xterm.js via Obsidian's Electron runtime. This gives you a fully interactive terminal — not just command execution.
+The plugin uses xterm.js for terminal rendering and node-pty for native pseudo-terminal support. node-pty spawns a real shell process (PowerShell, bash, etc.) and connects its stdin/stdout to xterm.js via Obsidian's Electron runtime. This gives you a fully interactive terminal - not just command execution.
 
 On Windows, the plugin uses the winpty backend because Obsidian's Electron renderer does not support Worker threads required by ConPTY.
 
 ## Session Persistence
 
-Each terminal tab's name, color, working directory, and scrollback buffer are saved to the workspace layout on close and on Obsidian quit. On next launch, tabs are restored with their history visible and a fresh shell spawned in the saved directory. This is visual/history restore — the underlying shell process does not survive quit.
+Each terminal tab's name, color, working directory, and scrollback buffer are saved to the workspace layout on close and on Obsidian quit. On next launch, tabs are restored with their history visible and a fresh shell spawned in the saved directory. This is visual/history restore - the underlying shell process does not survive quit.
 
 Closing a tab (**x** button) pushes its state to a rescue ring buffer stored in plugin data. Use **Restore recent terminal session** from the command palette to re-open a closed tab at any point.
 
@@ -97,7 +97,7 @@ Disabled by default. When enabled in settings, the plugin:
 - Registers the `obsidian://lean-terminal?resume=<session-id>` URI so links in the registry (or any note) open a new terminal tab and run `claude --resume <session-id>` once the shell is ready
 - Includes Claude sessions alongside recently closed tabs in the **Restore recent terminal session** picker, sorted by most recent
 
-Sessions started by typing `claude` manually inside a tab are not auto-tracked, but appear in the picker on its next open (the scan runs fresh each time) — click to resume.
+Sessions started by typing `claude` manually inside a tab are not auto-tracked, but appear in the picker on its next open (the scan runs fresh each time) - click to resume.
 
 ## Feedback
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,17 @@ npm run build        # Production build
 node install.mjs     # Install to default vault (D:\LOS Test)
 ```
 
+## Contributors
+
+This plugin is built and maintained by a dedicated community. Special thanks to:
+
+- **[@sdkasper](https://github.com/sdkasper)** (Sascha Kasper) — Core architecture, terminal lifecycle management, Windows/macOS/Linux platform support, binary download system, plugin distribution, and ongoing maintenance
+- **[@FarhadGSRX](https://github.com/FarhadGSRX)** — Session persistence, session rescue buffer, Claude Code integration with registry generation and resume links, color scheme catalog with themes.json support
+- **[@ckelsoe](https://github.com/ckelsoe)** — Per-tab color tint customization with editable palette, wiki-link autocomplete with path-insertion modes
+- **[@c00llin](https://github.com/c00llin)** — Terminal location options (Tab Right, Split Tab Right)
+- **[@kkugot](https://github.com/kkugot)** — Emoji rendering fixes, system theme detection with terminal color reporting protocol
+- **[@CHodder5](https://github.com/CHodder5)** — Zsh startup file forwarding (.zshenv and .zprofile) via ZDOTDIR override
+
 ## License
 
 [MIT](LICENSE)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,16 @@
 {
   "name": "lean-terminal",
-  "version": "0.9.5",
+  "version": "0.6.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lean-terminal",
-      "version": "0.9.5",
+      "version": "0.6.5",
       "license": "MIT",
       "dependencies": {
         "@xterm/addon-fit": "^0.10.0",
-        "@xterm/addon-search": "^0.16.0",
-        "@xterm/addon-unicode11": "^0.8.0",
+        "@xterm/addon-serialize": "^0.13.0",
         "@xterm/addon-web-links": "^0.11.0",
         "@xterm/xterm": "^5.5.0"
       },
@@ -496,8 +495,7 @@
       "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/codemirror": {
       "version": "5.60.8",
@@ -545,16 +543,10 @@
         "@xterm/xterm": "^5.0.0"
       }
     },
-    "node_modules/@xterm/addon-search": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@xterm/addon-search/-/addon-search-0.16.0.tgz",
-      "integrity": "sha512-9OeuBFu0/uZJPu+9AHKY6g/w0Czyb/Ut0A5t79I4ULoU4IfU5BEpPFVGQxP4zTTMdfZEYkVIRYbHBX1xWwjeSA==",
-      "license": "MIT"
-    },
-    "node_modules/@xterm/addon-unicode11": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@xterm/addon-unicode11/-/addon-unicode11-0.8.0.tgz",
-      "integrity": "sha512-LxinXu8SC4OmVa6FhgwsVCBZbr8WoSGzBl2+vqe8WcQ6hb1r6Gj9P99qTNdPiFPh4Ceiu2pC8xukZ6+2nnh49Q==",
+    "node_modules/@xterm/addon-serialize": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-serialize/-/addon-serialize-0.13.0.tgz",
+      "integrity": "sha512-kGs8o6LWAmN1l2NpMp01/YkpxbmO4UrfWybeGu79Khw5K9+Krp7XhXbBTOTc3GJRRhd6EmILjpR8k5+odY39YQ==",
       "license": "MIT",
       "peerDependencies": {
         "@xterm/xterm": "^5.0.0"
@@ -573,7 +565,8 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
       "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/builtin-modules": {
       "version": "4.0.0",
@@ -593,8 +586,7 @@
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -686,8 +678,7 @@
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
       "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -715,8 +706,7 @@
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -495,7 +495,8 @@
       "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
       "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/codemirror": {
       "version": "5.60.8",
@@ -565,8 +566,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
       "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/builtin-modules": {
       "version": "4.0.0",
@@ -586,7 +586,8 @@
       "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
       "integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -678,7 +679,8 @@
       "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
       "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/typescript": {
       "version": "5.9.3",
@@ -706,7 +708,8 @@
       "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
       "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lean-terminal",
-  "version": "0.9.6",
+  "version": "0.6.5",
   "description": "Embedded terminal for Obsidian using xterm.js and node-pty",
   "main": "main.js",
   "scripts": {
@@ -24,8 +24,7 @@
   },
   "dependencies": {
     "@xterm/addon-fit": "^0.10.0",
-    "@xterm/addon-search": "^0.16.0",
-    "@xterm/addon-unicode11": "^0.8.0",
+    "@xterm/addon-serialize": "^0.13.0",
     "@xterm/addon-web-links": "^0.11.0",
     "@xterm/xterm": "^5.5.0"
   }

--- a/src/binary-manager.ts
+++ b/src/binary-manager.ts
@@ -119,7 +119,8 @@ export class BinaryManager {
       }
 
       // Platform-specific checks
-      if (platform === "win32" && hasPrebuild) {
+      // winpty.dll is only shipped for win32-x64; ARM64 Windows uses ConPTY natively.
+      if (platform === "win32" && arch !== "arm64" && hasPrebuild) {
         const winpty = this.path.join(prebuildDir, "winpty.dll");
         if (!this.fs.existsSync(winpty)) {
           this.setStatus("not-installed");

--- a/src/claude-sessions.ts
+++ b/src/claude-sessions.ts
@@ -1,0 +1,270 @@
+import { Notice, TFile, FileSystemAdapter } from "obsidian";
+import type TerminalPlugin from "./main";
+import { openTabOrView } from "./terminal-opener";
+
+export interface ClaudeSessionEntry {
+  sessionId: string;
+  cwd: string;
+  firstPrompt: string;
+  summary: string;
+  modified: string; // ISO 8601
+  messageCount: number;
+  gitBranch: string;
+}
+
+interface SessionsIndexEntry {
+  sessionId: string;
+  firstPrompt?: string;
+  summary?: string;
+  modified?: string;
+  messageCount?: number;
+  gitBranch?: string;
+}
+
+/**
+ * Encode a filesystem path the way Claude Code does for its project directories.
+ * Any character outside [A-Za-z0-9-] becomes a hyphen.
+ * E.g. "C:\\_fg2" -> "C---fg2", "/home/user" -> "-home-user".
+ */
+export function encodeProjectDir(cwd: string): string {
+  return cwd.replace(/[^a-zA-Z0-9-]/g, "-");
+}
+
+/**
+ * Scan ~/.claude/projects/<encoded>/ for session JSONL files.
+ * Cross-references sessions-index.json for AI-generated summaries.
+ * Returns entries sorted by modified desc, capped at `max`.
+ */
+export async function scanClaudeProjectSessions(
+  cwd: string,
+  max: number
+): Promise<ClaudeSessionEntry[]> {
+  const path = window.require("path") as typeof import("path");
+  const os = window.require("os") as typeof import("os");
+  const fs = (window.require("fs") as typeof import("fs")).promises;
+
+  const encoded = encodeProjectDir(cwd);
+  const projectDir = path.join(os.homedir(), ".claude", "projects", encoded);
+
+  let files: string[];
+  try {
+    files = (await fs.readdir(projectDir)).filter((f) => f.endsWith(".jsonl"));
+  } catch {
+    return []; // no project directory for this vault
+  }
+
+  const indexMap = await readSessionsIndex(projectDir);
+
+  const entries: ClaudeSessionEntry[] = [];
+  for (const file of files) {
+    const fullPath = path.join(projectDir, file);
+    const sessionId = file.replace(/\.jsonl$/, "");
+    const indexed = indexMap.get(sessionId);
+
+    let firstPrompt = indexed?.firstPrompt ?? "";
+    let modified = indexed?.modified ?? "";
+    const messageCount = indexed?.messageCount ?? 0;
+    const gitBranch = indexed?.gitBranch ?? "";
+    const summary = indexed?.summary ?? "";
+
+    // Fill gaps from the JSONL itself (the sessions-index.json can lag)
+    if (!firstPrompt || !modified) {
+      try {
+        if (!modified) {
+          const stat = await fs.stat(fullPath);
+          modified = stat.mtime.toISOString();
+        }
+        if (!firstPrompt) {
+          firstPrompt = await readFirstUserPrompt(fullPath);
+        }
+      } catch {
+        continue; // skip unreadable files
+      }
+    }
+
+    entries.push({
+      sessionId,
+      cwd,
+      firstPrompt: cleanPrompt(firstPrompt),
+      summary: cleanPrompt(summary),
+      modified,
+      messageCount,
+      gitBranch,
+    });
+  }
+
+  entries.sort((a, b) => b.modified.localeCompare(a.modified));
+  return entries.slice(0, max);
+}
+
+async function readSessionsIndex(projectDir: string): Promise<Map<string, SessionsIndexEntry>> {
+  const path = window.require("path") as typeof import("path");
+  const fs = (window.require("fs") as typeof import("fs")).promises;
+  const map = new Map<string, SessionsIndexEntry>();
+
+  try {
+    const indexPath = path.join(projectDir, "sessions-index.json");
+    const content = await fs.readFile(indexPath, "utf-8");
+    const data = JSON.parse(content) as { entries?: SessionsIndexEntry[] };
+    if (Array.isArray(data.entries)) {
+      for (const e of data.entries) {
+        if (e.sessionId) map.set(e.sessionId, e);
+      }
+    }
+  } catch {
+    // missing or malformed index — scanner falls back to JSONL stats
+  }
+  return map;
+}
+
+/** Read the first user (non-meta) message in a JSONL session file, truncated. */
+async function readFirstUserPrompt(filePath: string): Promise<string> {
+  const fs = (window.require("fs") as typeof import("fs")).promises;
+  try {
+    const content = await fs.readFile(filePath, "utf-8");
+    const lines = content.split("\n");
+    for (const line of lines) {
+      if (!line.trim()) continue;
+      let msg: Record<string, unknown>;
+      try {
+        msg = JSON.parse(line) as Record<string, unknown>;
+      } catch {
+        continue;
+      }
+      if (msg.type !== "user" || msg.isMeta) continue;
+      const message = msg.message as { content?: unknown } | undefined;
+      const content = message?.content;
+      if (typeof content === "string") return truncate(content);
+      if (Array.isArray(content)) {
+        for (const block of content) {
+          if (
+            block && typeof block === "object" &&
+            (block as { type?: unknown }).type === "text" &&
+            typeof (block as { text?: unknown }).text === "string"
+          ) {
+            return truncate((block as { text: string }).text);
+          }
+        }
+      }
+    }
+  } catch {
+    // IO error — return empty string
+  }
+  return "";
+}
+
+/**
+ * Clean a prompt string that may contain Claude Code slash-command markup
+ * (e.g. "<command-name>/model</command-name> <command-message>model</command-message>...").
+ * Extracts the command name if present; otherwise strips any stray HTML-like tags.
+ */
+function cleanPrompt(raw: string): string {
+  if (!raw) return "";
+  const cmdMatch = raw.match(/<command-name>([^<]+)<\/command-name>/);
+  if (cmdMatch) return cmdMatch[1].trim();
+  return raw.replace(/<[^>]+>/g, "").replace(/\s+/g, " ").trim();
+}
+
+function truncate(s: string, max = 100): string {
+  const oneline = cleanPrompt(s);
+  return oneline.length > max ? oneline.slice(0, max - 1) + "\u2026" : oneline;
+}
+
+/**
+ * Refresh the Claude session registry note.
+ * Writes a markdown table at the configured path; creates the file if missing.
+ */
+export async function refreshClaudeRegistry(plugin: TerminalPlugin): Promise<void> {
+  if (!plugin.settings.enableClaudeIntegration) {
+    new Notice("Enable Claude Code integration in settings first.");
+    return;
+  }
+
+  const cwd = getVaultBasePath(plugin);
+  if (!cwd) {
+    new Notice("Could not determine vault path.");
+    return;
+  }
+
+  const entries = await scanClaudeProjectSessions(cwd, plugin.settings.claudeSessionsMax);
+  const markdown = generateRegistryMarkdown(entries);
+
+  try {
+    const abstract = plugin.app.vault.getAbstractFileByPath(plugin.settings.claudeRegistryPath);
+    if (abstract instanceof TFile) {
+      await plugin.app.vault.modify(abstract, markdown);
+    } else {
+      await plugin.app.vault.create(plugin.settings.claudeRegistryPath, markdown);
+    }
+    new Notice(`Claude registry: ${entries.length} session${entries.length === 1 ? "" : "s"}.`);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    new Notice(`Failed to write registry: ${msg}`);
+  }
+}
+
+function generateRegistryMarkdown(entries: ClaudeSessionEntry[]): string {
+  const header = [
+    "# Claude Sessions",
+    "",
+    `*Auto-maintained by Lean Terminal — last refreshed ${new Date().toISOString()}. Click a Resume link to reopen that Claude Code conversation in a new terminal tab.*`,
+    "",
+    "",
+  ].join("\n");
+
+  if (entries.length === 0) {
+    return header + "*No Claude sessions found for this vault.*\n";
+  }
+
+  const rows = entries.map((e) => {
+    const title = e.summary || e.firstPrompt || `(session ${e.sessionId.slice(0, 8)})`;
+    const branch = e.gitBranch || "\u2014";
+    const modified = e.modified ? e.modified.slice(0, 10) : "\u2014";
+    const msgs = e.messageCount > 0 ? String(e.messageCount) : "\u2014";
+    const resumeUri = `obsidian://lean-terminal?resume=${e.sessionId}`;
+    return `| ${escapeTableCell(title)} | ${branch} | ${msgs} | ${modified} | [Resume](${resumeUri}) |`;
+  });
+
+  return header + [
+    "| Session | Branch | Messages | Modified | |",
+    "|---------|--------|----------|----------|--|",
+    ...rows,
+    "",
+  ].join("\n");
+}
+
+function escapeTableCell(s: string): string {
+  return s.replace(/\|/g, "\\|").replace(/\n/g, " ");
+}
+
+/**
+ * Open a terminal tab that runs `claude --resume <sessionId>` on shell spawn.
+ * Called from the obsidian://lean-terminal?resume=... protocol handler.
+ */
+export async function resumeClaudeSession(
+  plugin: TerminalPlugin,
+  sessionId: string
+): Promise<void> {
+  if (!plugin.settings.enableClaudeIntegration) {
+    new Notice("Claude integration is disabled in settings.");
+    return;
+  }
+
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(sessionId)) {
+    new Notice("Invalid Claude session ID.");
+    return;
+  }
+
+  await openTabOrView(plugin, {
+    name: `Claude ${sessionId.slice(0, 8)}`,
+    color: "",
+    cwd: getVaultBasePath(plugin),
+    resumeCommand: `claude --resume ${sessionId}`,
+  });
+}
+
+function getVaultBasePath(plugin: TerminalPlugin): string {
+  const adapter = plugin.app.vault.adapter;
+  if (adapter instanceof FileSystemAdapter) return adapter.getBasePath();
+  return "";
+}

--- a/src/claude-sessions.ts
+++ b/src/claude-sessions.ts
@@ -93,7 +93,7 @@ export async function scanClaudeProjectSessions(
     });
   }
 
-  entries.sort((a, b) => b.modified.localeCompare(a.modified));
+  entries.sort((a, b) => Date.parse(b.modified) - Date.parse(a.modified));
   return entries.slice(0, max);
 }
 
@@ -133,9 +133,9 @@ async function readFirstUserPrompt(filePath: string): Promise<string> {
       }
       if (msg.type !== "user" || msg.isMeta) continue;
       const message = msg.message as { content?: unknown } | undefined;
-      const content = message?.content;
-      if (typeof content === "string") return truncate(content);
-      if (Array.isArray(content)) {
+      const msgContent = message?.content;
+      if (typeof msgContent === "string") return truncate(msgContent);
+      if (Array.isArray(msgContent)) {
         for (const block of content) {
           if (
             block && typeof block === "object" &&
@@ -207,7 +207,7 @@ function generateRegistryMarkdown(entries: ClaudeSessionEntry[]): string {
   const header = [
     "# Claude Sessions",
     "",
-    `*Auto-maintained by Lean Terminal — last refreshed ${new Date().toISOString()}. Click a Resume link to reopen that Claude Code conversation in a new terminal tab.*`,
+    `*Auto-maintained by Lean Terminal - last refreshed ${new Date().toISOString()}. Click a Resume link to reopen that Claude Code conversation in a new terminal tab.*`,
     "",
     "",
   ].join("\n");
@@ -218,9 +218,9 @@ function generateRegistryMarkdown(entries: ClaudeSessionEntry[]): string {
 
   const rows = entries.map((e) => {
     const title = e.summary || e.firstPrompt || `(session ${e.sessionId.slice(0, 8)})`;
-    const branch = e.gitBranch || "\u2014";
-    const modified = e.modified ? e.modified.slice(0, 10) : "\u2014";
-    const msgs = e.messageCount > 0 ? String(e.messageCount) : "\u2014";
+    const branch = e.gitBranch || "-";
+    const modified = e.modified ? e.modified.slice(0, 10) : "-";
+    const msgs = e.messageCount > 0 ? String(e.messageCount) : "-";
     const resumeUri = `obsidian://lean-terminal?resume=${e.sessionId}`;
     return `| ${escapeTableCell(title)} | ${branch} | ${msgs} | ${modified} | [Resume](${resumeUri}) |`;
   });
@@ -263,7 +263,7 @@ export async function resumeClaudeSession(
   });
 }
 
-function getVaultBasePath(plugin: TerminalPlugin): string {
+export function getVaultBasePath(plugin: TerminalPlugin): string {
   const adapter = plugin.app.vault.adapter;
   if (adapter instanceof FileSystemAdapter) return adapter.getBasePath();
   return "";

--- a/src/color-utils.ts
+++ b/src/color-utils.ts
@@ -1,0 +1,42 @@
+// Linear sRGB color mixing in JS. We need this because xterm.js's
+// `theme.background` is a solid color string (hex or rgb), not a CSS
+// expression, so `color-mix(...)` can't be used there.
+//
+// `mixHex("#1e1e1e", "#fc3634", 0.12)` → background tinted 12% toward tab color.
+
+function parseHex(hex: string): [number, number, number] | null {
+  const h = hex.trim().replace(/^#/, "");
+  if (h.length === 3) {
+    const r = parseInt(h[0] + h[0], 16);
+    const g = parseInt(h[1] + h[1], 16);
+    const b = parseInt(h[2] + h[2], 16);
+    if ([r, g, b].some(Number.isNaN)) return null;
+    return [r, g, b];
+  }
+  if (h.length === 6) {
+    const r = parseInt(h.slice(0, 2), 16);
+    const g = parseInt(h.slice(2, 4), 16);
+    const b = parseInt(h.slice(4, 6), 16);
+    if ([r, g, b].some(Number.isNaN)) return null;
+    return [r, g, b];
+  }
+  return null;
+}
+
+function toHex(v: number): string {
+  const clamped = Math.max(0, Math.min(255, Math.round(v)));
+  return clamped.toString(16).padStart(2, "0");
+}
+
+/**
+ * Mix `overlay` into `base` by `ratio` (0 = all base, 1 = all overlay).
+ * Returns a 6-digit hex string. If either input fails to parse, returns `base`.
+ */
+export function mixHex(base: string, overlay: string, ratio: number): string {
+  const b = parseHex(base);
+  const o = parseHex(overlay);
+  if (!b || !o) return base;
+  const r = Math.max(0, Math.min(1, ratio));
+  const mix = (i: 0 | 1 | 2): number => b[i] * (1 - r) + o[i] * r;
+  return `#${toHex(mix(0))}${toHex(mix(1))}${toHex(mix(2))}`;
+}

--- a/src/color-utils.ts
+++ b/src/color-utils.ts
@@ -1,8 +1,16 @@
-// Linear sRGB color mixing in JS. We need this because xterm.js's
-// `theme.background` is a solid color string (hex or rgb), not a CSS
-// expression, so `color-mix(...)` can't be used there.
+// Naive 8-bit sRGB channel mixing for terminal background tinting.
 //
-// `mixHex("#1e1e1e", "#fc3634", 0.12)` → background tinted 12% toward tab color.
+// We need this because xterm.js's `theme.background` is a solid color
+// string (only hex is parsed here), not a CSS expression, so `color-mix(...)`
+// can't be used at the xterm layer.
+//
+// Mixing happens in gamma-encoded sRGB (not sRGB-linear) since the
+// difference at the small tint ratios used here (typically <= 0.30) is
+// imperceptible and gamma decode/encode would add cost without visible
+// gain.
+//
+// `mixHex("#1e1e1e", "#fc3634", 0.12)` returns "#1e1e1e" tinted 12% toward
+// the tab color.
 
 function parseHex(hex: string): [number, number, number] | null {
   const h = hex.trim().replace(/^#/, "");

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,14 +3,13 @@ import { VIEW_TYPE_TERMINAL } from "./constants";
 import { TerminalView } from "./terminal-view";
 import { TerminalSettingTab, DEFAULT_SETTINGS, type TerminalPluginSettings } from "./settings";
 import { BinaryManager } from "./binary-manager";
-import { ThemeRegistry } from "./theme-registry";
+import { openRecentSessionPicker } from "./recent-sessions";
+import { refreshClaudeRegistry, resumeClaudeSession } from "./claude-sessions";
 
 export default class TerminalPlugin extends Plugin {
   settings: TerminalPluginSettings = DEFAULT_SETTINGS;
   binaryManager!: BinaryManager;
-  themeRegistry!: ThemeRegistry;
   private ribbonEl: HTMLElement | null = null;
-  private themeObserver: MutationObserver | null = null;
 
   async onload(): Promise<void> {
     await this.loadSettings();
@@ -24,10 +23,6 @@ export default class TerminalPlugin extends Plugin {
     );
     this.binaryManager = new BinaryManager(pluginDir);
     this.binaryManager.checkInstalled();
-
-    // Theme registry — loads optional themes.json from the plugin folder
-    this.themeRegistry = new ThemeRegistry(pluginDir);
-    await this.themeRegistry.load();
 
     // Register the terminal view
     this.registerView(VIEW_TYPE_TERMINAL, (leaf: WorkspaceLeaf) => {
@@ -70,27 +65,41 @@ export default class TerminalPlugin extends Plugin {
       callback: () => void this.openTerminalInNewPane(),
     });
 
+    this.addCommand({
+      id: "restore-recent-terminal-session",
+      name: "Restore recent terminal session",
+      callback: () => void openRecentSessionPicker(this),
+    });
+
+    this.addCommand({
+      id: "refresh-claude-session-registry",
+      name: "Refresh Claude session registry",
+      callback: () => void refreshClaudeRegistry(this),
+    });
+
+    // URI handler for clickable resume links in the registry note.
+    // Gating happens inside resumeClaudeSession — the handler is always registered
+    // so that flipping the setting doesn't require a plugin reload.
+    this.registerObsidianProtocolHandler("lean-terminal", (params) => {
+      if (params.resume) {
+        void resumeClaudeSession(this, params.resume);
+      }
+    });
+
     // Settings tab
     this.addSettingTab(new TerminalSettingTab(this.app, this));
 
-    // Watch for Obsidian theme changes (dark/light toggle)
-    this.themeObserver = new MutationObserver((mutations) => {
-      for (const m of mutations) {
-        if (m.type === "attributes" && m.attributeName === "class") {
-          // Only re-theme when user chose "system" (auto-follow Obsidian)
-          if (this.settings.theme === "system") {
-            this.updateTerminalThemes();
-          }
-        }
-      }
-    });
-    this.themeObserver.observe(document.body, { attributes: true, attributeFilter: ["class"] });
+    // Flush any pending layout save before Obsidian quits. Without this, a
+    // typed-then-quickly-quit scenario loses the last few seconds of activity
+    // because Obsidian's requestSaveLayout is debounced.
+    this.registerEvent(
+      this.app.workspace.on("quit", () => {
+        this.app.workspace.requestSaveLayout.run();
+      })
+    );
   }
 
   onunload(): void {
-    this.themeObserver?.disconnect();
-    this.themeObserver = null;
-
     // Detach after a tick to avoid disrupting the settings modal
     setTimeout(() => {
       this.app.workspace.detachLeavesOfType(VIEW_TYPE_TERMINAL);
@@ -104,21 +113,10 @@ export default class TerminalPlugin extends Plugin {
       return;
     }
 
-    let leaf: WorkspaceLeaf | null;
-    switch (this.settings.defaultLocation) {
-      case "right":
-        leaf = this.app.workspace.getRightLeaf(false);
-        break;
-      case "tab":
-        leaf = this.app.workspace.getLeaf("tab");
-        break;
-      case "split-right":
-        leaf = this.app.workspace.getLeaf("split", "vertical");
-        break;
-      default: // "bottom"
-        leaf = this.app.workspace.getLeaf("split", "horizontal");
-        break;
-    }
+    const leaf =
+      this.settings.defaultLocation === "right"
+        ? this.app.workspace.getRightLeaf(false)
+        : this.app.workspace.getLeaf("split", "horizontal");
 
     if (leaf) {
       await leaf.setViewState({ type: VIEW_TYPE_TERMINAL, active: true });
@@ -160,10 +158,6 @@ export default class TerminalPlugin extends Plugin {
 
   async loadSettings(): Promise<void> {
     this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
-    if ((this.settings.defaultLocation as string) === "tab-right") {
-      this.settings.defaultLocation = "tab";
-      await this.saveSettings();
-    }
   }
 
   async saveSettings(): Promise<void> {
@@ -185,23 +179,6 @@ export default class TerminalPlugin extends Plugin {
       // tabHeaderInnerIconEl is undocumented but stable across Obsidian versions
       const iconEl = (leaf as WorkspaceLeaf & { tabHeaderInnerIconEl?: HTMLElement }).tabHeaderInnerIconEl;
       if (iconEl) setIcon(iconEl, safeName);
-    }
-  }
-
-  /** Re-apply the full theme to all terminal views (e.g. after Obsidian dark/light switch). */
-  updateTerminalThemes(): void {
-    const leaves = this.app.workspace.getLeavesOfType(VIEW_TYPE_TERMINAL);
-    for (const leaf of leaves) {
-      const view = leaf.view as TerminalView;
-      view.updateTheme();
-    }
-  }
-
-  updateCopyOnSelect(): void {
-    const leaves = this.app.workspace.getLeavesOfType(VIEW_TYPE_TERMINAL);
-    for (const leaf of leaves) {
-      const view = leaf.view as TerminalView;
-      view.updateCopyOnSelect();
     }
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -179,6 +179,12 @@ export default class TerminalPlugin extends Plugin {
 
   async loadSettings(): Promise<void> {
     this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData());
+    // tabColors is the only array in settings. Object.assign is shallow,
+    // so on a fresh install (data.json has no tabColors) the merged
+    // settings would share the reference with DEFAULT_SETTINGS, and any
+    // push/filter mutation would leak into the module-level default.
+    // Deep-clone here so the default array stays immutable.
+    this.settings.tabColors = this.settings.tabColors.map((c) => ({ ...c }));
   }
 
   async saveSettings(): Promise<void> {

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,13 +3,16 @@ import { VIEW_TYPE_TERMINAL } from "./constants";
 import { TerminalView } from "./terminal-view";
 import { TerminalSettingTab, DEFAULT_SETTINGS, type TerminalPluginSettings } from "./settings";
 import { BinaryManager } from "./binary-manager";
+import { ThemeRegistry } from "./theme-registry";
 import { openRecentSessionPicker } from "./recent-sessions";
 import { refreshClaudeRegistry, resumeClaudeSession } from "./claude-sessions";
 
 export default class TerminalPlugin extends Plugin {
   settings: TerminalPluginSettings = DEFAULT_SETTINGS;
   binaryManager!: BinaryManager;
+  themeRegistry!: ThemeRegistry;
   private ribbonEl: HTMLElement | null = null;
+  private themeObserver: MutationObserver | null = null;
 
   async onload(): Promise<void> {
     await this.loadSettings();
@@ -23,6 +26,10 @@ export default class TerminalPlugin extends Plugin {
     );
     this.binaryManager = new BinaryManager(pluginDir);
     this.binaryManager.checkInstalled();
+
+    // Theme registry — loads optional themes.json from the plugin folder
+    this.themeRegistry = new ThemeRegistry(pluginDir);
+    await this.themeRegistry.load();
 
     // Register the terminal view
     this.registerView(VIEW_TYPE_TERMINAL, (leaf: WorkspaceLeaf) => {
@@ -100,6 +107,9 @@ export default class TerminalPlugin extends Plugin {
   }
 
   onunload(): void {
+    this.themeObserver?.disconnect();
+    this.themeObserver = null;
+
     // Detach after a tick to avoid disrupting the settings modal
     setTimeout(() => {
       this.app.workspace.detachLeavesOfType(VIEW_TYPE_TERMINAL);
@@ -113,10 +123,21 @@ export default class TerminalPlugin extends Plugin {
       return;
     }
 
-    const leaf =
-      this.settings.defaultLocation === "right"
-        ? this.app.workspace.getRightLeaf(false)
-        : this.app.workspace.getLeaf("split", "horizontal");
+    let leaf: WorkspaceLeaf | null;
+    switch (this.settings.defaultLocation) {
+      case "right":
+        leaf = this.app.workspace.getRightLeaf(false);
+        break;
+      case "tab":
+        leaf = this.app.workspace.getLeaf("tab");
+        break;
+      case "split-right":
+        leaf = this.app.workspace.getLeaf("split", "vertical");
+        break;
+      default: // "bottom"
+        leaf = this.app.workspace.getLeaf("split", "horizontal");
+        break;
+    }
 
     if (leaf) {
       await leaf.setViewState({ type: VIEW_TYPE_TERMINAL, active: true });
@@ -179,6 +200,14 @@ export default class TerminalPlugin extends Plugin {
       // tabHeaderInnerIconEl is undocumented but stable across Obsidian versions
       const iconEl = (leaf as WorkspaceLeaf & { tabHeaderInnerIconEl?: HTMLElement }).tabHeaderInnerIconEl;
       if (iconEl) setIcon(iconEl, safeName);
+    }
+  }
+
+  updateCopyOnSelect(): void {
+    const leaves = this.app.workspace.getLeavesOfType(VIEW_TYPE_TERMINAL);
+    for (const leaf of leaves) {
+      const view = leaf.view as TerminalView;
+      view.updateCopyOnSelect();
     }
   }
 }

--- a/src/recent-sessions.ts
+++ b/src/recent-sessions.ts
@@ -1,0 +1,149 @@
+import { FuzzySuggestModal, Notice, FileSystemAdapter } from "obsidian";
+import type TerminalPlugin from "./main";
+import type { RecentSession, SavedTab } from "./session-state";
+import type { CreateTabOpts } from "./terminal-tab-manager";
+import { openTabOrView } from "./terminal-opener";
+import {
+  scanClaudeProjectSessions,
+  type ClaudeSessionEntry,
+} from "./claude-sessions";
+
+/**
+ * Push a closed tab onto the recents ring buffer, trimmed to the configured max.
+ * Called from TerminalTabManager via the onSessionClose callback.
+ */
+export async function pushRecentSession(plugin: TerminalPlugin, tab: SavedTab): Promise<void> {
+  const max = plugin.settings.recentSessionsMax;
+  if (max <= 0) return;
+
+  const entry: RecentSession = { ...tab, closedAt: Date.now() };
+  plugin.settings.recentSessions.unshift(entry);
+  if (plugin.settings.recentSessions.length > max) {
+    plugin.settings.recentSessions.length = max;
+  }
+  await plugin.saveSettings();
+}
+
+/**
+ * Open the unified "Restore recent terminal session" picker.
+ * Shows recents always; also shows Claude sessions when that integration is enabled.
+ */
+export async function openRecentSessionPicker(plugin: TerminalPlugin): Promise<void> {
+  const recents = plugin.settings.recentSessions;
+
+  let claudeEntries: ClaudeSessionEntry[] = [];
+  if (plugin.settings.enableClaudeIntegration) {
+    const cwd = getVaultBasePath(plugin);
+    if (cwd) {
+      claudeEntries = await scanClaudeProjectSessions(cwd, plugin.settings.claudeSessionsMax);
+    }
+  }
+
+  if (recents.length === 0 && claudeEntries.length === 0) {
+    new Notice("No recent or Claude sessions to restore.");
+    return;
+  }
+
+  const items: PickerItem[] = [
+    ...recents.map((s): PickerItem => ({ kind: "recent", session: s, ts: s.closedAt })),
+    ...claudeEntries.map((s): PickerItem => ({
+      kind: "claude",
+      session: s,
+      ts: s.modified ? Date.parse(s.modified) : 0,
+    })),
+  ];
+
+  // Merge by recency — most recent first, regardless of source
+  items.sort((a, b) => b.ts - a.ts);
+
+  new UnifiedSessionPicker(plugin, items).open();
+}
+
+type PickerItem =
+  | { kind: "recent"; session: RecentSession; ts: number }
+  | { kind: "claude"; session: ClaudeSessionEntry; ts: number };
+
+class UnifiedSessionPicker extends FuzzySuggestModal<PickerItem> {
+  private plugin: TerminalPlugin;
+  private items: PickerItem[];
+
+  constructor(plugin: TerminalPlugin, items: PickerItem[]) {
+    super(plugin.app);
+    this.plugin = plugin;
+    this.items = items;
+    this.setPlaceholder("Pick a session to restore…");
+  }
+
+  getItems(): PickerItem[] {
+    return this.items;
+  }
+
+  getItemText(item: PickerItem): string {
+    if (item.kind === "recent") {
+      const s = item.session;
+      const age = relativeTime(Date.now() - s.closedAt);
+      return `[Recent] ${s.name} — ${s.cwd} (${age})`;
+    }
+    const s = item.session;
+    const title = s.summary || s.firstPrompt || `(${s.sessionId.slice(0, 8)})`;
+    const when = s.modified ? s.modified.slice(0, 10) : "unknown";
+    return `[Claude] ${title} (${when})`;
+  }
+
+  onChooseItem(item: PickerItem): void {
+    if (item.kind === "recent") {
+      void restoreRecent(this.plugin, item.session);
+    } else {
+      void restoreClaude(this.plugin, item.session);
+    }
+  }
+}
+
+/**
+ * Restore a recent terminal session: create a tab (or open a view) with the saved state.
+ * Consumes the entry from recents — closing the tab again will re-add it.
+ */
+async function restoreRecent(plugin: TerminalPlugin, session: RecentSession): Promise<void> {
+  const idx = plugin.settings.recentSessions.indexOf(session);
+  if (idx >= 0) {
+    plugin.settings.recentSessions.splice(idx, 1);
+    await plugin.saveSettings();
+  }
+
+  const opts: CreateTabOpts = {
+    name: session.name,
+    color: session.color,
+    cwd: session.cwd,
+    bufferSerial: session.bufferSerial,
+    resumeCommand: session.resumeCommand,
+  };
+  await openTabOrView(plugin, opts);
+}
+
+/** Restore a Claude Code session by running `claude --resume <uuid>` in a new tab. */
+async function restoreClaude(plugin: TerminalPlugin, entry: ClaudeSessionEntry): Promise<void> {
+  const opts: CreateTabOpts = {
+    name: `Claude ${entry.sessionId.slice(0, 8)}`,
+    color: "",
+    cwd: entry.cwd || getVaultBasePath(plugin),
+    resumeCommand: `claude --resume ${entry.sessionId}`,
+  };
+  await openTabOrView(plugin, opts);
+}
+
+function getVaultBasePath(plugin: TerminalPlugin): string {
+  const adapter = plugin.app.vault.adapter;
+  if (adapter instanceof FileSystemAdapter) return adapter.getBasePath();
+  return "";
+}
+
+function relativeTime(ms: number): string {
+  const sec = Math.floor(ms / 1000);
+  if (sec < 60) return sec <= 1 ? "just now" : `${sec}s ago`;
+  const min = Math.floor(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const days = Math.floor(hr / 24);
+  return `${days}d ago`;
+}

--- a/src/recent-sessions.ts
+++ b/src/recent-sessions.ts
@@ -5,6 +5,7 @@ import type { CreateTabOpts } from "./terminal-tab-manager";
 import { openTabOrView } from "./terminal-opener";
 import {
   scanClaudeProjectSessions,
+  getVaultBasePath,
   type ClaudeSessionEntry,
 } from "./claude-sessions";
 
@@ -82,7 +83,7 @@ class UnifiedSessionPicker extends FuzzySuggestModal<PickerItem> {
     if (item.kind === "recent") {
       const s = item.session;
       const age = relativeTime(Date.now() - s.closedAt);
-      return `[Recent] ${s.name} — ${s.cwd} (${age})`;
+      return `[Recent] ${s.name} - ${s.cwd} (${age})`;
     }
     const s = item.session;
     const title = s.summary || s.firstPrompt || `(${s.sessionId.slice(0, 8)})`;
@@ -129,12 +130,6 @@ async function restoreClaude(plugin: TerminalPlugin, entry: ClaudeSessionEntry):
     resumeCommand: `claude --resume ${entry.sessionId}`,
   };
   await openTabOrView(plugin, opts);
-}
-
-function getVaultBasePath(plugin: TerminalPlugin): string {
-  const adapter = plugin.app.vault.adapter;
-  if (adapter instanceof FileSystemAdapter) return adapter.getBasePath();
-  return "";
 }
 
 function relativeTime(ms: number): string {

--- a/src/session-state.ts
+++ b/src/session-state.ts
@@ -19,7 +19,7 @@ export interface SavedTab {
   bufferSerial?: string;
   /**
    * Command to run after the shell spawns on restore
-   * (e.g. "claude --resume <uuid>"). Reserved for Stage C.
+   * (e.g. "claude --resume <uuid>").
    */
   resumeCommand?: string;
 }

--- a/src/session-state.ts
+++ b/src/session-state.ts
@@ -1,0 +1,41 @@
+/**
+ * Shared types for terminal session persistence.
+ *
+ * SavedTab is the unit of persistence — one per terminal session (tab).
+ * SavedViewState is what TerminalView.getState/setState serialize.
+ */
+
+export interface SavedTab {
+  /** User-visible tab name (e.g. "Terminal 3" or a renamed value). */
+  name: string;
+  /** Tab accent color (hex or empty). Matches TAB_COLORS values. */
+  color: string;
+  /** Working directory when the session was started. */
+  cwd: string;
+  /**
+   * Serialized xterm.js buffer (from @xterm/addon-serialize).
+   * Absent when persistBuffer setting is off, or when nothing has been written yet.
+   */
+  bufferSerial?: string;
+  /**
+   * Command to run after the shell spawns on restore
+   * (e.g. "claude --resume <uuid>"). Reserved for Stage C.
+   */
+  resumeCommand?: string;
+}
+
+export interface SavedViewState {
+  /** Tabs in their original left-to-right order. */
+  tabs: SavedTab[];
+  /** Index of the tab that was active when state was captured. */
+  activeIndex: number;
+}
+
+/**
+ * A SavedTab captured at close time, for the recent-sessions rescue buffer.
+ * Stored in plugin data (data.json), not in workspace.json.
+ */
+export interface RecentSession extends SavedTab {
+  /** Epoch ms when the tab was closed. */
+  closedAt: number;
+}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -77,7 +77,7 @@ export class TerminalSettingTab extends PluginSettingTab {
     container.createDiv({
       cls: "setting-item-description",
       text:
-        "Palette shown in each tab's right-click menu. Built-in colors can be retuned but not deleted or renamed. Tint strength is per-color (0-" +
+        "Palette shown in each tab's right-click menu. Built-in colors keep their name and hex, but their tint can be adjusted. Custom colors below can be fully edited (name, hex, tint) or deleted. Tint strength is per-color (0-" +
         MAX_TINT_STRENGTH +
         "%) so each color can be dialed to stay readable in the CLI it gets paired with.",
     });

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,5 +1,6 @@
 import { App, ColorComponent, DropdownComponent, Notice, PluginSettingTab, Setting, setIcon } from "obsidian";
 import type TerminalPlugin from "./main";
+import type { RecentSession } from "./session-state";
 
 export type NotificationSound = "beep" | "chime" | "ping" | "pop";
 
@@ -18,6 +19,13 @@ export interface TerminalPluginSettings {
   notificationSound: NotificationSound;
   notificationVolume: number;
   searchShortcut: string;
+  persistBuffer: boolean;
+  recentSessionsMax: number;
+  recentSessions: RecentSession[];
+  // Claude Code integration — all gated on enableClaudeIntegration
+  enableClaudeIntegration: boolean;
+  claudeRegistryPath: string;
+  claudeSessionsMax: number;
 }
 
 export const DEFAULT_SETTINGS: TerminalPluginSettings = {
@@ -35,6 +43,12 @@ export const DEFAULT_SETTINGS: TerminalPluginSettings = {
   notificationSound: "beep",
   notificationVolume: 50,
   searchShortcut: "Ctrl+Alt+F",
+  persistBuffer: true,
+  recentSessionsMax: 10,
+  recentSessions: [],
+  enableClaudeIntegration: false,
+  claudeRegistryPath: "claude-sessions.md",
+  claudeSessionsMax: 25,
 };
 
 export class TerminalSettingTab extends PluginSettingTab {
@@ -401,11 +415,99 @@ export class TerminalSettingTab extends PluginSettingTab {
           })
       );
 
+<<<<<<< HEAD
     // --- About ---
     new Setting(containerEl).setName("About").setHeading();
 
     new Setting(containerEl)
       .setName("Plugin version")
       .setDesc(`Lean Obsidian Terminal v${this.plugin.manifest.version}`);
+=======
+    // --- Session Persistence ---
+    new Setting(containerEl).setName("Session persistence").setHeading();
+
+    new Setting(containerEl)
+      .setName("Persist terminal buffer")
+      .setDesc(
+        "Save scrollback history across restarts so restored tabs show prior output. Disable to reduce workspace.json size."
+      )
+      .addToggle((toggle) =>
+        toggle.setValue(this.plugin.settings.persistBuffer).onChange(async (value) => {
+          this.plugin.settings.persistBuffer = value;
+          await this.plugin.saveSettings();
+        })
+      );
+
+    new Setting(containerEl)
+      .setName("Recent sessions to keep")
+      .setDesc(
+        "When a tab is closed, its state is kept for rescue via \"Restore recent terminal session\". Set to 0 to disable."
+      )
+      .addText((text) =>
+        text
+          .setValue(String(this.plugin.settings.recentSessionsMax))
+          .onChange(async (value) => {
+            const num = parseInt(value, 10);
+            if (!isNaN(num) && num >= 0) {
+              this.plugin.settings.recentSessionsMax = num;
+              // Trim the existing ring buffer if the new max is smaller
+              if (this.plugin.settings.recentSessions.length > num) {
+                this.plugin.settings.recentSessions.length = num;
+              }
+              await this.plugin.saveSettings();
+            }
+          })
+      );
+
+    // --- Claude Code Integration ---
+    new Setting(containerEl).setName("Claude Code integration").setHeading();
+
+    new Setting(containerEl)
+      .setName("Enable Claude Code integration")
+      .setDesc(
+        "Scan ~/.claude/ for conversation sessions, register the obsidian://lean-terminal URI handler for resume links, and show Claude sessions in the restore picker."
+      )
+      .addToggle((toggle) =>
+        toggle.setValue(this.plugin.settings.enableClaudeIntegration).onChange(async (value) => {
+          this.plugin.settings.enableClaudeIntegration = value;
+          await this.plugin.saveSettings();
+          this.display(); // rebuild UI to show/hide Claude-specific settings
+        })
+      );
+
+    if (this.plugin.settings.enableClaudeIntegration) {
+      new Setting(containerEl)
+        .setName("Registry note path")
+        .setDesc(
+          "Vault-relative path to the auto-generated Claude sessions registry note. Created on first refresh."
+        )
+        .addText((text) =>
+          text
+            .setPlaceholder("claude-sessions.md")
+            .setValue(this.plugin.settings.claudeRegistryPath)
+            .onChange(async (value) => {
+              this.plugin.settings.claudeRegistryPath = value.trim() || "claude-sessions.md";
+              await this.plugin.saveSettings();
+            })
+        );
+
+      new Setting(containerEl)
+        .setName("Registry sessions to keep")
+        .setDesc(
+          "Maximum number of most-recent Claude sessions to list in the registry note and picker. Older sessions remain accessible via /resume."
+        )
+        .addText((text) =>
+          text
+            .setValue(String(this.plugin.settings.claudeSessionsMax))
+            .onChange(async (value) => {
+              const num = parseInt(value, 10);
+              if (!isNaN(num) && num > 0) {
+                this.plugin.settings.claudeSessionsMax = num;
+                await this.plugin.saveSettings();
+              }
+            })
+        );
+    }
+>>>>>>> a30db32 (feat: session management — persistence, rescue, Claude Code integration)
   }
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -112,7 +112,7 @@ export class TerminalSettingTab extends PluginSettingTab {
     row.setDesc(color.builtin ? `${color.value} - built-in` : color.value);
 
     if (!color.builtin) {
-      row.addText((text) =>
+      row.addText((text) => {
         text
           .setPlaceholder("Name")
           .setValue(color.name)
@@ -126,8 +126,9 @@ export class TerminalSettingTab extends PluginSettingTab {
             }
             color.name = trimmed;
             await this.plugin.saveSettings();
-          }),
-      );
+          });
+        text.inputEl.addEventListener("blur", () => this.display());
+      });
 
       row.addColorPicker((picker) =>
         picker.setValue(color.value).onChange(async (value) => {
@@ -486,10 +487,13 @@ export class TerminalSettingTab extends PluginSettingTab {
           this.plugin.settings.tabColorTintsBackground = value;
           await this.plugin.saveSettings();
           this.plugin.updateTerminalBackgrounds();
+          this.display();
         }),
       );
 
-    this.renderTabColorsSection(containerEl);
+    if (this.plugin.settings.tabColorTintsBackground) {
+      this.renderTabColorsSection(containerEl);
+    }
 
     new Setting(containerEl)
       .setName("Cursor blink")

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,6 +1,12 @@
 import { App, ColorComponent, DropdownComponent, Notice, PluginSettingTab, Setting, setIcon } from "obsidian";
 import type TerminalPlugin from "./main";
 import type { RecentSession } from "./session-state";
+import {
+  DEFAULT_TAB_COLORS,
+  DEFAULT_TINT_STRENGTH,
+  MAX_TINT_STRENGTH,
+  type TabColorDef,
+} from "./tab-colors";
 
 export type NotificationSound = "beep" | "chime" | "ping" | "pop";
 
@@ -26,6 +32,8 @@ export interface TerminalPluginSettings {
   enableClaudeIntegration: boolean;
   claudeRegistryPath: string;
   claudeSessionsMax: number;
+  tabColorTintsBackground: boolean;
+  tabColors: TabColorDef[];
 }
 
 export const DEFAULT_SETTINGS: TerminalPluginSettings = {
@@ -49,14 +57,173 @@ export const DEFAULT_SETTINGS: TerminalPluginSettings = {
   enableClaudeIntegration: false,
   claudeRegistryPath: "claude-sessions.md",
   claudeSessionsMax: 25,
+  tabColorTintsBackground: true,
+  tabColors: DEFAULT_TAB_COLORS.map((c) => ({ ...c })),
 };
 
 export class TerminalSettingTab extends PluginSettingTab {
   plugin: TerminalPlugin;
+  private pendingNewColorName = "";
+  private pendingNewColorHex = "#888888";
 
   constructor(app: App, plugin: TerminalPlugin) {
     super(app, plugin);
     this.plugin = plugin;
+  }
+
+  private renderTabColorsSection(container: HTMLElement): void {
+    new Setting(container).setName("Tab colors").setHeading();
+
+    container.createDiv({
+      cls: "setting-item-description",
+      text:
+        "Palette shown in each tab's right-click menu. Built-in colors can be retuned but not deleted or renamed. Tint strength is per-color (0-" +
+        MAX_TINT_STRENGTH +
+        "%) so each color can be dialed to stay readable in the CLI it gets paired with.",
+    });
+
+    for (const color of this.plugin.settings.tabColors) {
+      if (!color.value) continue; // skip "None"
+      this.renderTabColorRow(container, color);
+    }
+
+    this.renderAddColorRow(container);
+
+    new Setting(container)
+      .addButton((btn) =>
+        btn
+          .setButtonText("Reset palette to defaults")
+          .setWarning()
+          .onClick(async () => {
+            this.plugin.settings.tabColors = DEFAULT_TAB_COLORS.map((c) => ({ ...c }));
+            await this.plugin.saveSettings();
+            this.plugin.updateTerminalBackgrounds();
+            this.display();
+          }),
+      );
+  }
+
+  private renderTabColorRow(container: HTMLElement, color: TabColorDef): void {
+    const row = new Setting(container);
+
+    const swatch = row.nameEl.createSpan({ cls: "lean-color-swatch" });
+    swatch.style.background = color.value;
+    row.nameEl.createSpan({ text: color.name });
+    row.setDesc(color.builtin ? `${color.value} - built-in` : color.value);
+
+    if (!color.builtin) {
+      row.addText((text) =>
+        text
+          .setPlaceholder("Name")
+          .setValue(color.name)
+          .onChange(async (value) => {
+            const trimmed = value.trim();
+            if (!trimmed) return;
+            if (
+              this.plugin.settings.tabColors.some((c) => c !== color && c.name === trimmed)
+            ) {
+              return;
+            }
+            color.name = trimmed;
+            await this.plugin.saveSettings();
+          }),
+      );
+
+      row.addColorPicker((picker) =>
+        picker.setValue(color.value).onChange(async (value) => {
+          color.value = value;
+          await this.plugin.saveSettings();
+          this.plugin.updateTerminalBackgrounds();
+          swatch.style.background = value;
+        }),
+      );
+    }
+
+    row.addSlider((slider) =>
+      slider
+        .setLimits(0, MAX_TINT_STRENGTH, 1)
+        .setValue(color.tintStrength)
+        .setDynamicTooltip()
+        .onChange(async (value) => {
+          color.tintStrength = value;
+          await this.plugin.saveSettings();
+          this.plugin.updateTerminalBackgrounds();
+        }),
+    );
+
+    if (color.builtin) {
+      row.addButton((btn) =>
+        btn
+          .setButtonText("Reset")
+          .setTooltip("Reset tint to default")
+          .onClick(async () => {
+            color.tintStrength = DEFAULT_TINT_STRENGTH;
+            await this.plugin.saveSettings();
+            this.plugin.updateTerminalBackgrounds();
+            this.display();
+          }),
+      );
+    } else {
+      row.addExtraButton((btn) =>
+        btn
+          .setIcon("trash")
+          .setTooltip("Delete color")
+          .onClick(async () => {
+            this.plugin.settings.tabColors = this.plugin.settings.tabColors.filter(
+              (c) => c !== color,
+            );
+            await this.plugin.saveSettings();
+            this.plugin.updateTerminalBackgrounds();
+            this.display();
+          }),
+      );
+    }
+  }
+
+  private renderAddColorRow(container: HTMLElement): void {
+    const setting = new Setting(container).setName("Add custom color");
+
+    setting.addText((text) =>
+      text
+        .setPlaceholder("Name")
+        .setValue(this.pendingNewColorName)
+        .onChange((value) => {
+          this.pendingNewColorName = value;
+        }),
+    );
+
+    setting.addColorPicker((picker) =>
+      picker.setValue(this.pendingNewColorHex).onChange((value) => {
+        this.pendingNewColorHex = value;
+      }),
+    );
+
+    setting.addButton((btn) =>
+      btn
+        .setButtonText("Add")
+        .setCta()
+        .onClick(async () => {
+          const name = this.pendingNewColorName.trim();
+          if (!name) {
+            new Notice("Color name is required.");
+            return;
+          }
+          if (this.plugin.settings.tabColors.some((c) => c.name === name)) {
+            new Notice("A color with that name already exists.");
+            return;
+          }
+          this.plugin.settings.tabColors.push({
+            name,
+            value: this.pendingNewColorHex,
+            tintStrength: DEFAULT_TINT_STRENGTH,
+            builtin: false,
+          });
+          this.pendingNewColorName = "";
+          this.pendingNewColorHex = "#888888";
+          await this.plugin.saveSettings();
+          this.display();
+        }),
+    );
   }
 
   display(): void {
@@ -310,6 +477,19 @@ export class TerminalSettingTab extends PluginSettingTab {
         this.plugin.updateTerminalBackgrounds();
       });
     });
+
+    new Setting(containerEl)
+      .setName("Tab color tints terminal background")
+      .setDesc("Mix a colored tab's swatch into the terminal background. Per-color tint strength is configured below.")
+      .addToggle((toggle) =>
+        toggle.setValue(this.plugin.settings.tabColorTintsBackground).onChange(async (value) => {
+          this.plugin.settings.tabColorTintsBackground = value;
+          await this.plugin.saveSettings();
+          this.plugin.updateTerminalBackgrounds();
+        }),
+      );
+
+    this.renderTabColorsSection(containerEl);
 
     new Setting(containerEl)
       .setName("Cursor blink")

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -415,14 +415,6 @@ export class TerminalSettingTab extends PluginSettingTab {
           })
       );
 
-<<<<<<< HEAD
-    // --- About ---
-    new Setting(containerEl).setName("About").setHeading();
-
-    new Setting(containerEl)
-      .setName("Plugin version")
-      .setDesc(`Lean Obsidian Terminal v${this.plugin.manifest.version}`);
-=======
     // --- Session Persistence ---
     new Setting(containerEl).setName("Session persistence").setHeading();
 
@@ -508,6 +500,12 @@ export class TerminalSettingTab extends PluginSettingTab {
             })
         );
     }
->>>>>>> a30db32 (feat: session management — persistence, rescue, Claude Code integration)
+
+    // --- About ---
+    new Setting(containerEl).setName("About").setHeading();
+
+    new Setting(containerEl)
+      .setName("Plugin version")
+      .setDesc(`Lean Obsidian Terminal v${this.plugin.manifest.version}`);
   }
 }

--- a/src/tab-colors.ts
+++ b/src/tab-colors.ts
@@ -1,0 +1,34 @@
+// Tab color palette: built-in entries seeded on first run, plus any
+// user-defined colors added in Settings. Each entry carries its own tint
+// strength so users can dial the terminal-background mix per color
+// (e.g. softer red for CLIs with lots of red output).
+
+export interface TabColorDef {
+  name: string;
+  value: string;        // "" for the None entry, otherwise 6-digit hex
+  tintStrength: number; // percent, 0..30 (stored as a percent integer)
+  builtin: boolean;     // true = seeded preset, not deletable/renamable
+}
+
+export const DEFAULT_TAB_COLORS: TabColorDef[] = [
+  { name: "None",      value: "",        tintStrength: 0,  builtin: true },
+  { name: "Vermilion", value: "#FC3634", tintStrength: 12, builtin: true },
+  { name: "Sky Blue",  value: "#25D0F7", tintStrength: 12, builtin: true },
+  { name: "Gold",      value: "#FFD700", tintStrength: 12, builtin: true },
+  { name: "Mint",      value: "#18BC9C", tintStrength: 12, builtin: true },
+  { name: "Azure",     value: "#007BFF", tintStrength: 12, builtin: true },
+  { name: "Purple",    value: "#A991D4", tintStrength: 12, builtin: true },
+];
+
+export const MAX_TINT_STRENGTH = 30;
+export const DEFAULT_TINT_STRENGTH = 12;
+
+/** Look up the palette entry matching `hex`. Falls back to a synthetic
+ *  entry using the default tint strength when the session was colored with
+ *  a hex no longer present in the palette. */
+export function findTabColor(palette: TabColorDef[], hex: string): TabColorDef | null {
+  if (!hex) return null;
+  const match = palette.find((c) => c.value.toLowerCase() === hex.toLowerCase());
+  if (match) return match;
+  return { name: hex, value: hex, tintStrength: DEFAULT_TINT_STRENGTH, builtin: false };
+}

--- a/src/terminal-opener.ts
+++ b/src/terminal-opener.ts
@@ -1,0 +1,42 @@
+import type TerminalPlugin from "./main";
+import type { CreateTabOpts } from "./terminal-tab-manager";
+import type { TerminalView } from "./terminal-view";
+import { VIEW_TYPE_TERMINAL } from "./constants";
+
+/**
+ * Open a tab in the existing terminal view, or open a fresh view and replace
+ * its default tab with our opts. We can't round-trip opts through setViewState's
+ * state field because CreateTabOpts fields like `runResumeCommand` aren't part
+ * of SavedTab — they're transient creation hints. Destroy-and-recreate
+ * preserves them; the default tab has no user activity yet, so saveToRecents=false.
+ */
+export async function openTabOrView(plugin: TerminalPlugin, opts: CreateTabOpts): Promise<void> {
+  const existingLeaves = plugin.app.workspace.getLeavesOfType(VIEW_TYPE_TERMINAL);
+  if (existingLeaves.length > 0) {
+    const view = existingLeaves[0].view as TerminalView;
+    const manager = view.getTabManager();
+    if (manager) {
+      manager.createTab(opts);
+      void plugin.app.workspace.revealLeaf(existingLeaves[0]);
+      return;
+    }
+  }
+
+  const leaf =
+    plugin.settings.defaultLocation === "right"
+      ? plugin.app.workspace.getRightLeaf(false)
+      : plugin.app.workspace.getLeaf("split", "horizontal");
+  if (!leaf) return;
+
+  await leaf.setViewState({ type: VIEW_TYPE_TERMINAL, active: true });
+  void plugin.app.workspace.revealLeaf(leaf);
+
+  const view = leaf.view as TerminalView;
+  const manager = view.getTabManager();
+  if (!manager) return;
+
+  // onOpen just created a default tab (no saved state came in via setViewState);
+  // replace it with our configured tab.
+  manager.destroyAll(false);
+  manager.createTab(opts);
+}

--- a/src/terminal-tab-manager.ts
+++ b/src/terminal-tab-manager.ts
@@ -212,13 +212,15 @@ function tintRatioForColor(color: string, settings: TerminalPluginSettings): num
   return (def?.tintStrength ?? DEFAULT_TINT_STRENGTH) / 100;
 }
 
-/** Theme with the per-session tab color mixed into the background. */
+/** Theme with the per-session tab color mixed into the background.
+ *  resolveTerminalTheme already returns a fresh object (ThemeRegistry.get
+ *  clones), so we mutate its background in place rather than spreading again. */
 function resolveSessionTheme(
   session: Pick<TerminalSession, "color">,
   settings: TerminalPluginSettings,
   registry: ThemeRegistry,
 ) {
-  const theme = { ...resolveTerminalTheme(settings, registry) };
+  const theme = resolveTerminalTheme(settings, registry);
   const ratio = tintRatioForColor(session.color, settings);
   if (ratio > 0 && theme.background) {
     theme.background = mixHex(theme.background, session.color, ratio);

--- a/src/terminal-tab-manager.ts
+++ b/src/terminal-tab-manager.ts
@@ -5,12 +5,11 @@ import { WebLinksAddon } from "@xterm/addon-web-links";
 import { SerializeAddon } from "@xterm/addon-serialize";
 import type { IDisposable } from "@xterm/xterm";
 import { PtyManager } from "./pty-manager";
-import { getTheme, isObsidianDark } from "./themes";
+import { isObsidianDark } from "./themes";
 import { mixHex } from "./color-utils";
-import { findTabColor, DEFAULT_TINT_STRENGTH } from "./tab-colors";
+import { findTabColor, DEFAULT_TINT_STRENGTH, MAX_TINT_STRENGTH } from "./tab-colors";
 import { ThemeRegistry } from "./theme-registry";
-import type { TerminalPluginSettings } from "./settings";
-import type { NotificationSound } from "./settings";
+import type { TerminalPluginSettings, NotificationSound } from "./settings";
 import type { BinaryManager } from "./binary-manager";
 import type { SavedTab } from "./session-state";
 
@@ -207,7 +206,8 @@ function resolveTerminalTheme(settings: TerminalPluginSettings, registry: ThemeR
 function tintRatioForColor(color: string, settings: TerminalPluginSettings): number {
   if (!color || !settings.tabColorTintsBackground) return 0;
   const def = findTabColor(settings.tabColors, color);
-  return (def?.tintStrength ?? DEFAULT_TINT_STRENGTH) / 100;
+  const strength = Math.min(MAX_TINT_STRENGTH, Math.max(0, def?.tintStrength ?? DEFAULT_TINT_STRENGTH));
+  return strength / 100;
 }
 
 /** Theme with the per-session tab color mixed into the background.
@@ -433,16 +433,16 @@ export class TerminalTabManager {
     const containerEl = this.terminalHostEl.createDiv({ cls: "terminal-session" });
 
     // Create xterm.js instance
-    const theme = getTheme(this.settings.theme);
-    if (this.settings.backgroundColor) {
-      theme.background = this.settings.backgroundColor;
-    }
     const terminal = new Terminal({
       fontSize: this.settings.fontSize,
       fontFamily: this.settings.fontFamily,
       cursorBlink: this.settings.cursorBlink,
       scrollback: this.settings.scrollback,
-      theme,
+      theme: resolveSessionTheme(
+        { color: opts?.color ?? "" },
+        this.settings,
+        this.themeRegistry,
+      ),
     });
 
     const fitAddon = new FitAddon();
@@ -682,6 +682,7 @@ export class TerminalTabManager {
    * (e.g. setState after onOpen's default-tab creation) to avoid polluting recents.
    */
   destroyAll(saveToRecents = true): void {
+    document.querySelector(".terminal-tab-context-menu")?.remove();
     for (const session of this.sessions) {
       if (saveToRecents) {
         this.onSessionClose?.(this.captureSession(session));

--- a/src/terminal-tab-manager.ts
+++ b/src/terminal-tab-manager.ts
@@ -3,22 +3,67 @@ import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { SerializeAddon } from "@xterm/addon-serialize";
+import type { IDisposable } from "@xterm/xterm";
 import { PtyManager } from "./pty-manager";
 import { getTheme } from "./themes";
+import { mixHex } from "./color-utils";
+import { findTabColor, DEFAULT_TINT_STRENGTH } from "./tab-colors";
 import type { TerminalPluginSettings } from "./settings";
 import type { NotificationSound } from "./settings";
 import type { BinaryManager } from "./binary-manager";
 import type { SavedTab } from "./session-state";
 
-export const TAB_COLORS = [
-  { name: "None", value: "" },
-  { name: "Red", value: "#e54d4d" },
-  { name: "Orange", value: "#e8a838" },
-  { name: "Yellow", value: "#e5d74e" },
-  { name: "Green", value: "#4ec955" },
-  { name: "Blue", value: "#4e9de5" },
-  { name: "Purple", value: "#b04ee5" },
-] as const;
+const SEARCH_DECORATIONS = {
+  matchBackground: "#ffff00",
+  matchBorder: "#ffff00",
+  matchOverviewRuler: "#ffff00",
+  activeMatchBackground: "#ff6600",
+  activeMatchBorder: "#ff0000",
+  activeMatchColorOverviewRuler: "#ff0000",
+} as const;
+
+interface ParsedShortcut {
+  ctrl: boolean;
+  shift: boolean;
+  alt: boolean;
+  meta: boolean;
+  key: string;
+}
+
+function parseShortcut(s: string): ParsedShortcut | null {
+  if (!s.trim()) return null;
+  const parts = s.split("+");
+  const key = parts[parts.length - 1];
+  const lower = parts.map((p) => p.toLowerCase());
+  return {
+    ctrl: lower.includes("ctrl"),
+    shift: lower.includes("shift"),
+    alt: lower.includes("alt"),
+    meta: lower.includes("meta") || lower.includes("cmd"),
+    key,
+  };
+}
+
+function matchesShortcut(e: KeyboardEvent, shortcut: string): boolean {
+  const p = parseShortcut(shortcut);
+  if (!p) return false;
+  return (
+    e.ctrlKey === p.ctrl &&
+    e.shiftKey === p.shift &&
+    e.altKey === p.alt &&
+    e.metaKey === p.meta &&
+    e.key.toLowerCase() === p.key.toLowerCase()
+  );
+}
+
+const SEARCH_DECORATIONS = {
+  matchBackground: "#ffff00",
+  matchBorder: "#ffff00",
+  matchOverviewRuler: "#ffff00",
+  activeMatchBackground: "#ff6600",
+  activeMatchBorder: "#ff0000",
+  activeMatchColorOverviewRuler: "#ff0000",
+} as const;
 
 export interface TerminalSession {
   id: string;
@@ -125,6 +170,161 @@ function playNotificationSound(sound: NotificationSound, volume: number): void {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Terminal color reporting helpers (OSC 10/11, Mode 2031)
+// ---------------------------------------------------------------------------
+
+const ESC = "\x1b";
+const BEL = "\x07";
+const HEX6_RE = /^#[0-9a-fA-F]{6}$/;
+
+/** Convert "#RRGGBB" hex to X11 "rgb:RRRR/GGGG/BBBB" (16-bit per component). */
+function hexToX11(hex: string): string {
+  if (!HEX6_RE.test(hex)) return "rgb:0000/0000/0000";
+  const r = hex.slice(1, 3);
+  const g = hex.slice(3, 5);
+  const b = hex.slice(5, 7);
+  return `rgb:${r}${r}/${g}${g}/${b}${b}`;
+}
+
+/** Get the effective foreground color for a session. */
+function sessionForeground(session: TerminalSession): string {
+  return (session.terminal.options.theme?.foreground) || "#d4d4d4";
+}
+
+/** Get the effective background color for a session. */
+function sessionBackground(session: TerminalSession): string {
+  return (session.terminal.options.theme?.background) || "#1e1e1e";
+}
+
+function resolveTerminalTheme(settings: TerminalPluginSettings, registry: ThemeRegistry) {
+  const theme = registry.get(settings.theme);
+  if (settings.backgroundColor) {
+    theme.background = settings.backgroundColor;
+  }
+  return theme;
+}
+
+/** Percent (0..MAX_TINT_STRENGTH) used to mix `color` into the terminal background. */
+function tintRatioForColor(color: string, settings: TerminalPluginSettings): number {
+  if (!color || !settings.tabColorTintsBackground) return 0;
+  const def = findTabColor(settings.tabColors, color);
+  return (def?.tintStrength ?? DEFAULT_TINT_STRENGTH) / 100;
+}
+
+/** Theme with the per-session tab color mixed into the background. */
+function resolveSessionTheme(
+  session: Pick<TerminalSession, "color">,
+  settings: TerminalPluginSettings,
+  registry: ThemeRegistry,
+) {
+  const theme = { ...resolveTerminalTheme(settings, registry) };
+  const ratio = tintRatioForColor(session.color, settings);
+  if (ratio > 0 && theme.background) {
+    theme.background = mixHex(theme.background, session.color, ratio);
+  }
+  return theme;
+}
+
+/**
+ * Register OSC 10/11 query handlers and Mode 2031 / CSI ?996n handlers
+ * on a terminal session. Responses are written back to the PTY so the child
+ * app reads them from stdin — matching real terminal behavior.
+ */
+function registerColorReporting(session: TerminalSession): void {
+  const { terminal, pty } = session;
+  const d: IDisposable[] = session.parserDisposables;
+
+  // --- OSC 10 ; ? — query default foreground color ---
+  d.push(terminal.parser.registerOscHandler(10, (data: string) => {
+    if (data !== "?") return false; // not a query, let default handler run
+    const color = hexToX11(sessionForeground(session));
+    pty.write(`${ESC}]10;${color}${BEL}`);
+    return true;
+  }));
+
+  // --- OSC 11 ; ? — query default background color ---
+  d.push(terminal.parser.registerOscHandler(11, (data: string) => {
+    if (data !== "?") return false;
+    const color = hexToX11(sessionBackground(session));
+    pty.write(`${ESC}]11;${color}${BEL}`);
+    return true;
+  }));
+
+  // --- CSI ? 996 n — one-shot dark/light mode query ---
+  d.push(terminal.parser.registerCsiHandler({ prefix: "?", final: "n" }, (params) => {
+    if (params[0] !== 996) return false;
+    const mode = isObsidianDark() ? 1 : 2; // 1 = dark, 2 = light
+    pty.write(`${ESC}[?997;${mode}n`);
+    return true;
+  }));
+
+  // --- CSI ? 2031 h — enable Mode 2031 (color-scheme-change notifications) ---
+  d.push(terminal.parser.registerCsiHandler({ prefix: "?", final: "h" }, (params) => {
+    if (params[0] !== 2031) return false;
+    session.mode2031 = true;
+    return true;
+  }));
+
+  // --- CSI ? 2031 l — disable Mode 2031 ---
+  d.push(terminal.parser.registerCsiHandler({ prefix: "?", final: "l" }, (params) => {
+    if (params[0] !== 2031) return false;
+    session.mode2031 = false;
+    return true;
+  }));
+}
+
+function quotePath(rawPath: string, shellPath: string): string {
+  if (!rawPath.includes(' ')) return rawPath;
+  const lower = shellPath.toLowerCase();
+  if (lower.includes('bash') || lower.includes('zsh') || lower.includes('sh')) {
+    return `'${rawPath}'`;
+  }
+  return `"${rawPath}"`;
+}
+
+interface ElectronFile extends File { path?: string; }
+interface ObsidianAppInternal extends App {
+  dragManager?: { draggable?: { file?: { path: string } } };
+}
+
+function extractDropPath(e: DragEvent, app: App): string | null {
+  // OS file drag via text/uri-list (file:// URLs in Electron)
+  const uriList = e.dataTransfer?.getData('text/uri-list');
+  if (uriList) {
+    const uri = uriList.split('\n')[0].trim();
+    if (uri.startsWith('file://')) {
+      const path = window.require('url').fileURLToPath(uri);
+      return path;
+    }
+  }
+
+  // OS file drag via dataTransfer.files — use Electron webUtils (Electron 32+) with .path fallback
+  if (e.dataTransfer?.files.length) {
+    const file = e.dataTransfer.files[0];
+    try {
+      const { webUtils } = window.require('electron') as { webUtils: { getPathForFile: (file: File) => string } };
+      const p = webUtils.getPathForFile(file);
+      if (p) return p;
+    } catch {
+      const p = (file as ElectronFile).path;
+      if (p) return p;
+    }
+  }
+
+  // Obsidian internal file drag
+  const draggable = (app as ObsidianAppInternal).dragManager?.draggable;
+  if (draggable?.file) {
+    const basePath = (app.vault.adapter as FileSystemAdapter).getBasePath();
+    const vaultPath = draggable.file.path.split('/').join(window.require('path').sep);
+    const fullPath = window.require('path').join(basePath, vaultPath);
+    return fullPath;
+  }
+
+  return null;
+}
+
+>>>>>>> 9d8db06 (feat: per-tab color tint with editable palette)
 export class TerminalTabManager {
   private sessions: TerminalSession[] = [];
   private activeId: string | null = null;
@@ -552,7 +752,7 @@ export class TerminalTabManager {
     menu.createDiv({ cls: "terminal-ctx-item terminal-ctx-color-label", text: "Color" });
     const colorRow = menu.createDiv({ cls: "terminal-ctx-color-row" });
 
-    for (const c of TAB_COLORS) {
+    for (const c of this.settings.tabColors) {
       const swatch = colorRow.createDiv({ cls: "terminal-ctx-swatch" });
       if (c.value) {
         swatch.style.background = c.value;
@@ -565,6 +765,9 @@ export class TerminalTabManager {
       swatch.title = c.name;
       swatch.addEventListener("click", () => {
         session.color = c.value;
+        // Picking a new color reapplies the session theme so a tinted
+        // background reflects the new swatch immediately.
+        session.terminal.options.theme = resolveSessionTheme(session, this.settings, this.themeRegistry);
         this.renderTabBar();
         this.requestSaveLayout?.();
         menu.remove();
@@ -584,12 +787,22 @@ export class TerminalTabManager {
   }
 
   updateBackgroundColor(): void {
-    const theme = getTheme(this.settings.theme);
-    if (this.settings.backgroundColor) {
-      theme.background = this.settings.backgroundColor;
-    }
     for (const session of this.sessions) {
-      session.terminal.options.theme = { ...session.terminal.options.theme, background: theme.background };
+      session.terminal.options.theme = resolveSessionTheme(session, this.settings, this.themeRegistry);
+    }
+  }
+
+  /** Re-apply the full theme to all sessions (used when Obsidian switches dark/light). */
+  updateTheme(): void {
+    const isDark = isObsidianDark();
+    for (const session of this.sessions) {
+      session.terminal.options.theme = resolveSessionTheme(session, this.settings, this.themeRegistry);
+
+      // Notify child apps that opted into Mode 2031 color-scheme-change updates
+      if (session.mode2031) {
+        const mode = isDark ? 1 : 2; // 1 = dark, 2 = light
+        session.pty.write(`${ESC}[?997;${mode}n`);
+      }
     }
   }
 
@@ -601,14 +814,19 @@ export class TerminalTabManager {
     this.tabBarEl.empty();
 
     for (const session of this.sessions) {
-      const tab = this.tabBarEl.createDiv({
-        cls: `terminal-tab${session.id === this.activeId ? " active" : ""}`,
-      });
+      const classes = ["terminal-tab"];
+      if (session.id === this.activeId) classes.push("active");
+      if (session.pinned) classes.push("terminal-tab--pinned");
+      if (session.color) classes.push("terminal-tab--colored");
+      const tab = this.tabBarEl.createDiv({ cls: classes.join(" ") });
 
-      // Apply tab color as left border + active highlight
+      // Tab color drives two CSS variables. All visual rules (border + tinted
+      // fill across idle/hover/active states) live in styles.css so we don't
+      // hardcode opacity values here.
       if (session.color) {
-        tab.style.borderLeft = `3px solid ${session.color}`;
         tab.style.setProperty("--tab-accent", session.color);
+        const def = findTabColor(this.settings.tabColors, session.color);
+        tab.style.setProperty("--tab-color-intensity", String(def?.tintStrength ?? DEFAULT_TINT_STRENGTH));
       }
 
       const label = tab.createSpan({ cls: "terminal-tab-label", text: session.name });

--- a/src/terminal-tab-manager.ts
+++ b/src/terminal-tab-manager.ts
@@ -1,68 +1,23 @@
-import { Notice, App, FileSystemAdapter } from "obsidian";
+import { Notice } from "obsidian";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
-import { Unicode11Addon } from "@xterm/addon-unicode11";
-import { SearchAddon } from "@xterm/addon-search";
+import { SerializeAddon } from "@xterm/addon-serialize";
 import { PtyManager } from "./pty-manager";
-import type { ThemeRegistry } from "./theme-registry";
-import { isObsidianDark } from "./themes";
+import { getTheme } from "./themes";
 import type { TerminalPluginSettings } from "./settings";
 import type { NotificationSound } from "./settings";
 import type { BinaryManager } from "./binary-manager";
-import type { IDisposable } from "@xterm/xterm";
-
-const SEARCH_DECORATIONS = {
-  matchBackground: "#ffff00",
-  matchBorder: "#ffff00",
-  matchOverviewRuler: "#ffff00",
-  activeMatchBackground: "#ff6600",
-  activeMatchBorder: "#ff0000",
-  activeMatchColorOverviewRuler: "#ff0000",
-} as const;
-
-interface ParsedShortcut {
-  ctrl: boolean;
-  shift: boolean;
-  alt: boolean;
-  meta: boolean;
-  key: string;
-}
-
-function parseShortcut(s: string): ParsedShortcut | null {
-  if (!s.trim()) return null;
-  const parts = s.split("+");
-  const key = parts[parts.length - 1];
-  const lower = parts.map((p) => p.toLowerCase());
-  return {
-    ctrl: lower.includes("ctrl"),
-    shift: lower.includes("shift"),
-    alt: lower.includes("alt"),
-    meta: lower.includes("meta") || lower.includes("cmd"),
-    key,
-  };
-}
-
-function matchesShortcut(e: KeyboardEvent, shortcut: string): boolean {
-  const p = parseShortcut(shortcut);
-  if (!p) return false;
-  return (
-    e.ctrlKey === p.ctrl &&
-    e.shiftKey === p.shift &&
-    e.altKey === p.alt &&
-    e.metaKey === p.meta &&
-    e.key.toLowerCase() === p.key.toLowerCase()
-  );
-}
+import type { SavedTab } from "./session-state";
 
 export const TAB_COLORS = [
   { name: "None", value: "" },
-  { name: "Vermilion", value: "#FC3634" },
-  { name: "Sky Blue", value: "#25D0F7" },
-  { name: "Gold", value: "#FFD700" },
-  { name: "Mint", value: "#18BC9C" },
-  { name: "Azure", value: "#007BFF" },
-  { name: "Purple", value: "#A991D4" },
+  { name: "Red", value: "#e54d4d" },
+  { name: "Orange", value: "#e8a838" },
+  { name: "Yellow", value: "#e5d74e" },
+  { name: "Green", value: "#4ec955" },
+  { name: "Blue", value: "#4e9de5" },
+  { name: "Purple", value: "#b04ee5" },
 ] as const;
 
 export interface TerminalSession {
@@ -70,18 +25,23 @@ export interface TerminalSession {
   name: string;
   terminal: Terminal;
   fitAddon: FitAddon;
+  serializeAddon: SerializeAddon;
   pty: PtyManager;
   containerEl: HTMLElement;
   color: string;
-  /** Whether this session has opted into Mode 2031 color-scheme-change notifications. */
-  mode2031: boolean;
-  /** Disposables for parser handlers (cleaned up on tab close). */
-  parserDisposables: IDisposable[];
-  dragLabel: HTMLElement;
-  searchAddon: SearchAddon;
-  overlayEl: HTMLElement;
-  toggleSearch: () => void;
-  pinned: boolean;
+  /** Working directory the shell was spawned in. */
+  cwd: string;
+  /** Reserved for Stage C: command to re-run on restore (e.g. "claude --resume <uuid>"). */
+  resumeCommand?: string;
+}
+
+/** Options for restoring a tab from persisted state (via setState). */
+export interface CreateTabOpts {
+  name?: string;
+  color?: string;
+  cwd?: string;
+  bufferSerial?: string;
+  resumeCommand?: string;
 }
 
 let sessionCounter = 0;
@@ -165,139 +125,6 @@ function playNotificationSound(sound: NotificationSound, volume: number): void {
   }
 }
 
-// ---------------------------------------------------------------------------
-// Terminal color reporting helpers (OSC 10/11, Mode 2031)
-// ---------------------------------------------------------------------------
-
-const ESC = "\x1b";
-const BEL = "\x07";
-const HEX6_RE = /^#[0-9a-fA-F]{6}$/;
-
-/** Convert "#RRGGBB" hex to X11 "rgb:RRRR/GGGG/BBBB" (16-bit per component). */
-function hexToX11(hex: string): string {
-  if (!HEX6_RE.test(hex)) return "rgb:0000/0000/0000";
-  const r = hex.slice(1, 3);
-  const g = hex.slice(3, 5);
-  const b = hex.slice(5, 7);
-  return `rgb:${r}${r}/${g}${g}/${b}${b}`;
-}
-
-/** Get the effective foreground color for a session. */
-function sessionForeground(session: TerminalSession): string {
-  return (session.terminal.options.theme?.foreground) || "#d4d4d4";
-}
-
-/** Get the effective background color for a session. */
-function sessionBackground(session: TerminalSession): string {
-  return (session.terminal.options.theme?.background) || "#1e1e1e";
-}
-
-function resolveTerminalTheme(settings: TerminalPluginSettings, registry: ThemeRegistry) {
-  const theme = registry.get(settings.theme);
-  if (settings.backgroundColor) {
-    theme.background = settings.backgroundColor;
-  }
-  return theme;
-}
-
-/**
- * Register OSC 10/11 query handlers and Mode 2031 / CSI ?996n handlers
- * on a terminal session. Responses are written back to the PTY so the child
- * app reads them from stdin — matching real terminal behavior.
- */
-function registerColorReporting(session: TerminalSession): void {
-  const { terminal, pty } = session;
-  const d: IDisposable[] = session.parserDisposables;
-
-  // --- OSC 10 ; ? — query default foreground color ---
-  d.push(terminal.parser.registerOscHandler(10, (data: string) => {
-    if (data !== "?") return false; // not a query, let default handler run
-    const color = hexToX11(sessionForeground(session));
-    pty.write(`${ESC}]10;${color}${BEL}`);
-    return true;
-  }));
-
-  // --- OSC 11 ; ? — query default background color ---
-  d.push(terminal.parser.registerOscHandler(11, (data: string) => {
-    if (data !== "?") return false;
-    const color = hexToX11(sessionBackground(session));
-    pty.write(`${ESC}]11;${color}${BEL}`);
-    return true;
-  }));
-
-  // --- CSI ? 996 n — one-shot dark/light mode query ---
-  d.push(terminal.parser.registerCsiHandler({ prefix: "?", final: "n" }, (params) => {
-    if (params[0] !== 996) return false;
-    const mode = isObsidianDark() ? 1 : 2; // 1 = dark, 2 = light
-    pty.write(`${ESC}[?997;${mode}n`);
-    return true;
-  }));
-
-  // --- CSI ? 2031 h — enable Mode 2031 (color-scheme-change notifications) ---
-  d.push(terminal.parser.registerCsiHandler({ prefix: "?", final: "h" }, (params) => {
-    if (params[0] !== 2031) return false;
-    session.mode2031 = true;
-    return true;
-  }));
-
-  // --- CSI ? 2031 l — disable Mode 2031 ---
-  d.push(terminal.parser.registerCsiHandler({ prefix: "?", final: "l" }, (params) => {
-    if (params[0] !== 2031) return false;
-    session.mode2031 = false;
-    return true;
-  }));
-}
-
-function quotePath(rawPath: string, shellPath: string): string {
-  if (!rawPath.includes(' ')) return rawPath;
-  const lower = shellPath.toLowerCase();
-  if (lower.includes('bash') || lower.includes('zsh') || lower.includes('sh')) {
-    return `'${rawPath}'`;
-  }
-  return `"${rawPath}"`;
-}
-
-interface ElectronFile extends File { path?: string; }
-interface ObsidianAppInternal extends App {
-  dragManager?: { draggable?: { file?: { path: string } } };
-}
-
-function extractDropPath(e: DragEvent, app: App): string | null {
-  // OS file drag via text/uri-list (file:// URLs in Electron)
-  const uriList = e.dataTransfer?.getData('text/uri-list');
-  if (uriList) {
-    const uri = uriList.split('\n')[0].trim();
-    if (uri.startsWith('file://')) {
-      const path = window.require('url').fileURLToPath(uri);
-      return path;
-    }
-  }
-
-  // OS file drag via dataTransfer.files — use Electron webUtils (Electron 32+) with .path fallback
-  if (e.dataTransfer?.files.length) {
-    const file = e.dataTransfer.files[0];
-    try {
-      const { webUtils } = window.require('electron') as { webUtils: { getPathForFile: (file: File) => string } };
-      const p = webUtils.getPathForFile(file);
-      if (p) return p;
-    } catch {
-      const p = (file as ElectronFile).path;
-      if (p) return p;
-    }
-  }
-
-  // Obsidian internal file drag
-  const draggable = (app as ObsidianAppInternal).dragManager?.draggable;
-  if (draggable?.file) {
-    const basePath = (app.vault.adapter as FileSystemAdapter).getBasePath();
-    const vaultPath = draggable.file.path.split('/').join(window.require('path').sep);
-    const fullPath = window.require('path').join(basePath, vaultPath);
-    return fullPath;
-  }
-
-  return null;
-}
-
 export class TerminalTabManager {
   private sessions: TerminalSession[] = [];
   private activeId: string | null = null;
@@ -307,200 +134,142 @@ export class TerminalTabManager {
   private cwd: string;
   private pluginDir: string;
   private binaryManager: BinaryManager;
-  private themeRegistry: ThemeRegistry;
   private onActiveChange?: () => void;
   private onTabsEmpty?: () => void;
-  private dragSrcId: string | null = null;
-  private app: App;
+  private requestSaveLayout?: () => void;
+  private onSessionClose?: (tab: SavedTab) => void;
+  /** Set true by any terminal write/resize; consumed by the view's periodic save timer. */
+  private outputDirty = false;
 
   constructor(
-    app: App,
     tabBarEl: HTMLElement,
     terminalHostEl: HTMLElement,
     settings: TerminalPluginSettings,
     cwd: string,
     pluginDir: string,
     binaryManager: BinaryManager,
-    themeRegistry: ThemeRegistry,
     onActiveChange?: () => void,
-    onTabsEmpty?: () => void
+    onTabsEmpty?: () => void,
+    requestSaveLayout?: () => void,
+    onSessionClose?: (tab: SavedTab) => void
   ) {
-    this.app = app;
     this.tabBarEl = tabBarEl;
     this.terminalHostEl = terminalHostEl;
     this.settings = settings;
     this.cwd = cwd;
     this.pluginDir = pluginDir;
     this.binaryManager = binaryManager;
-    this.themeRegistry = themeRegistry;
     this.onActiveChange = onActiveChange;
     this.onTabsEmpty = onTabsEmpty;
+    this.requestSaveLayout = requestSaveLayout;
+    this.onSessionClose = onSessionClose;
   }
 
-  createTab(): TerminalSession {
+  /** Capture a session's current state as a SavedTab (used on close for recents). */
+  private captureSession(session: TerminalSession): SavedTab {
+    return {
+      name: session.name,
+      color: session.color,
+      cwd: session.cwd,
+      bufferSerial: this.settings.persistBuffer ? session.serializeAddon.serialize() : undefined,
+      resumeCommand: session.resumeCommand,
+    };
+  }
+
+  /**
+   * Consume the dirty flag: returns true if output/resize happened since last call,
+   * resetting it. Used by the view's periodic save timer.
+   */
+  consumeOutputDirty(): boolean {
+    const was = this.outputDirty;
+    this.outputDirty = false;
+    return was;
+  }
+
+  /**
+   * Install an OSC 133 handler + fallback timer that writes `resumeCommand` to the
+   * PTY once the shell is ready (signalled by OSC 133 A). Called from createTab
+   * before pty.spawn so the handler catches the very first prompt.
+   */
+  private setupAutoResume(session: TerminalSession, terminal: Terminal): void {
+    let executed = false;
+    let fallbackTimer: ReturnType<typeof setTimeout> | null = null;
+    let oscDisposable: { dispose: () => void } | null = null;
+
+    const cleanup = (): void => {
+      if (fallbackTimer) { clearTimeout(fallbackTimer); fallbackTimer = null; }
+      if (oscDisposable) { oscDisposable.dispose(); oscDisposable = null; }
+    };
+
+    const runCommand = (): void => {
+      if (executed || !session.resumeCommand) return;
+      executed = true;
+      cleanup();
+      const command = session.resumeCommand;
+      session.resumeCommand = undefined;
+      session.pty.write(command + "\r");
+      this.requestSaveLayout?.();
+    };
+
+    // Primary trigger: shell emits OSC 133 A ("prompt start") when ready for input
+    oscDisposable = terminal.parser.registerOscHandler(133, (data) => {
+      if (data.startsWith("A")) runCommand();
+      return false; // allow other handlers to run
+    });
+
+    // Fallback for shells without OSC 133 support (e.g. cmd.exe): run after 2s
+    fallbackTimer = setTimeout(runCommand, 2000);
+  }
+
+  createTab(opts?: CreateTabOpts): TerminalSession {
     sessionCounter++;
     const id = `terminal-${sessionCounter}`;
-    const name = `Terminal ${sessionCounter}`;
+    const name = opts?.name ?? `Terminal ${sessionCounter}`;
+    const sessionCwd = opts?.cwd ?? this.cwd;
 
     // Create container for this session
     const containerEl = this.terminalHostEl.createDiv({ cls: "terminal-session" });
 
     // Create xterm.js instance
-    const theme = resolveTerminalTheme(this.settings, this.themeRegistry);
+    const theme = getTheme(this.settings.theme);
+    if (this.settings.backgroundColor) {
+      theme.background = this.settings.backgroundColor;
+    }
     const terminal = new Terminal({
       fontSize: this.settings.fontSize,
       fontFamily: this.settings.fontFamily,
       cursorBlink: this.settings.cursorBlink,
       scrollback: this.settings.scrollback,
-      allowProposedApi: true,
       theme,
     });
 
     const fitAddon = new FitAddon();
-    const webLinksAddon = new WebLinksAddon((event, uri) => {
-      const { shell } = window.require("electron") as {
-        shell: { openExternal: (url: string) => Promise<void> };
-      };
-      void shell.openExternal(uri);
-    });
-    const unicode11Addon = new Unicode11Addon();
-    const searchAddon = new SearchAddon();
+    const webLinksAddon = new WebLinksAddon();
+    const serializeAddon = new SerializeAddon();
 
     terminal.loadAddon(fitAddon);
     terminal.loadAddon(webLinksAddon);
-    terminal.loadAddon(unicode11Addon);
-    terminal.loadAddon(searchAddon);
-    terminal.unicode.activeVersion = "11";
+    terminal.loadAddon(serializeAddon);
     terminal.open(containerEl);
 
-    // Drag-and-drop file path insertion
-    const dragLabel = document.body.createDiv({ cls: 'terminal-drag-label' });
-    dragLabel.setText('Paste path to file');
+    // Replay prior buffer (from persisted state) before the PTY produces new output.
+    // No visual marker is written — markers become part of the serialized buffer and
+    // accumulate across restores.
+    if (opts?.bufferSerial) {
+      terminal.write(opts.bufferSerial);
+    }
 
-    // Search overlay
-    const overlayEl = containerEl.createDiv({ cls: "lean-terminal-search-overlay" });
-    const searchInput = overlayEl.createEl("input", { type: "text" });
-    searchInput.addClass("lean-terminal-search-input");
-    searchInput.placeholder = "Find...";
-    const counterEl = overlayEl.createSpan({ cls: "lean-terminal-search-counter" });
-    const prevBtn = overlayEl.createEl("button", { cls: "lean-terminal-search-btn", text: "↑" });
-    const nextBtn = overlayEl.createEl("button", { cls: "lean-terminal-search-btn", text: "↓" });
-    const caseBtn = overlayEl.createEl("button", { cls: "lean-terminal-search-btn", text: "Aa" });
-    const closeBtn = overlayEl.createEl("button", { cls: "lean-terminal-search-btn", text: "×" });
-
-    let caseSensitive = false;
-
-    const runSearch = (forward: boolean, incremental = false) => {
-      const q = searchInput.value;
-      const opts = { caseSensitive, incremental, decorations: SEARCH_DECORATIONS };
-      if (forward) {
-        searchAddon.findNext(q, opts);
-      } else {
-        searchAddon.findPrevious(q, opts);
-      }
-    };
-
-    const resultsDisposable = searchAddon.onDidChangeResults((result) => {
-      if (!result || result.resultCount === 0) {
-        counterEl.setText(searchInput.value ? "No results" : "");
-      } else {
-        counterEl.setText(`${result.resultIndex + 1} of ${result.resultCount}`);
-      }
-    });
-
-    const showSearch = () => {
-      overlayEl.addClass("lean-terminal-search-overlay--visible");
-      if (searchInput.value) runSearch(true, true);
-      searchInput.focus();
-    };
-
-    const hideSearch = () => {
-      overlayEl.removeClass("lean-terminal-search-overlay--visible");
-      searchAddon.clearDecorations();
-      counterEl.setText("");
-      terminal.focus();
-    };
-
-    const toggleSearch = () => {
-      if (overlayEl.hasClass("lean-terminal-search-overlay--visible")) {
-        hideSearch();
-      } else {
-        showSearch();
-      }
-    };
-
-    searchInput.addEventListener("input", () => runSearch(true, true));
-
-    searchInput.addEventListener("keydown", (e) => {
-      if (e.key === "Enter") {
-        e.preventDefault();
-        if (e.shiftKey) runSearch(false);
-        else runSearch(true);
-      } else if (e.key === "Escape") {
-        hideSearch();
-      }
-    });
-
-    nextBtn.addEventListener("click", () => runSearch(true));
-    prevBtn.addEventListener("click", () => runSearch(false));
-
-    caseBtn.addEventListener("click", () => {
-      caseSensitive = !caseSensitive;
-      caseBtn.toggleClass("lean-terminal-search-btn--active", caseSensitive);
-      if (searchInput.value) runSearch(true, true);
-    });
-
-    closeBtn.addEventListener("click", () => hideSearch());
-
-    const isFileDrag = (e: DragEvent): boolean =>
-      !!e.dataTransfer?.types.includes('Files') ||
-      !!(this.app as ObsidianAppInternal).dragManager?.draggable;
-
-    const showLabel = (e: DragEvent) => {
-      dragLabel.addClass('terminal-drag-label-visible');
-      dragLabel.style.left = `${e.clientX + 14}px`;
-      dragLabel.style.top = `${e.clientY + 14}px`;
-    };
-    const hideLabel = () => { dragLabel.removeClass('terminal-drag-label-visible'); };
-
-    containerEl.addEventListener('dragenter', (e) => {
-      if (!isFileDrag(e)) return;
-      e.preventDefault();
-      showLabel(e);
-    });
-
-    containerEl.addEventListener('dragover', (e) => {
-      if (!isFileDrag(e)) return;
-      e.preventDefault();
-      e.dataTransfer!.dropEffect = 'copy';
-      showLabel(e);
-    });
-
-    containerEl.addEventListener('dragleave', (e) => {
-      if (!containerEl.contains(e.relatedTarget as Node)) hideLabel();
-    });
-
-    containerEl.addEventListener('drop', (e) => {
-      e.preventDefault();
-      hideLabel();
-
-      const path = extractDropPath(e, this.app);
-      if (!path) return;
-      pty.write(quotePath(path, pty.shellPath));
-    });
+    // Mark "output changed since last save" so the view's periodic timer can
+    // trigger a save. We avoid calling requestSaveLayout on every write because
+    // heavy output (e.g. Claude streaming) caused visible input lag when every
+    // chunk scheduled a debounced save-which-serializes-the-whole-buffer.
+    terminal.onWriteParsed(() => { this.outputDirty = true; });
+    terminal.onResize(() => { this.outputDirty = true; });
 
     // Intercept clipboard shortcuts — Obsidian captures them before xterm.js
     terminal.attachCustomKeyEventHandler((e: KeyboardEvent) => {
       if (e.type !== "keydown") return true;
       const mod = e.metaKey || e.ctrlKey;
-
-      // Search shortcut
-      if (matchesShortcut(e, this.settings.searchShortcut)) {
-        e.preventDefault();
-        const s = this.sessions.find((s) => s.id === id);
-        if (s) s.toggleSearch();
-        return false;
-      }
 
       // Shift+Enter: send newline without submitting
       if (e.shiftKey && e.key === "Enter") {
@@ -513,7 +282,7 @@ export class TerminalTabManager {
       // Paste: Ctrl+V / Cmd+V / Shift+Insert
       if ((mod && e.key === "v") || (e.shiftKey && e.key === "Insert")) {
         e.preventDefault();
-        void navigator.clipboard.readText().then((text) => {
+        navigator.clipboard.readText().then((text) => {
           if (text) {
             const s = this.sessions.find((s) => s.id === id);
             if (s) s.pty.write(text);
@@ -524,7 +293,7 @@ export class TerminalTabManager {
 
       // Copy: Ctrl+C / Cmd+C when there is a selection (otherwise send SIGINT)
       if (mod && e.key === "c" && terminal.hasSelection()) {
-        void navigator.clipboard.writeText(terminal.getSelection()).catch(() => {});
+        navigator.clipboard.writeText(terminal.getSelection()).catch(() => {});
         terminal.clearSelection();
         return false;
       }
@@ -534,32 +303,35 @@ export class TerminalTabManager {
 
     const pty = new PtyManager(this.pluginDir);
     const session: TerminalSession = {
-      id, name, terminal, fitAddon, pty, containerEl, color: "",
-      mode2031: false,
-      parserDisposables: [],
-      dragLabel,
-      searchAddon,
-      overlayEl,
-      toggleSearch,
-      pinned: false,
+      id,
+      name,
+      terminal,
+      fitAddon,
+      serializeAddon,
+      pty,
+      containerEl,
+      color: opts?.color ?? "",
+      cwd: sessionCwd,
+      resumeCommand: opts?.resumeCommand,
     };
-
-    // Register terminal color reporting (OSC 10/11, Mode 2031)
-    registerColorReporting(session);
-    session.parserDisposables.push(resultsDisposable);
-
-    terminal.onSelectionChange(() => {
-      if (!this.settings.copyOnSelect) return;
-      const text = terminal.getSelection();
-      if (text) void navigator.clipboard.writeText(text);
-    });
-
     this.sessions.push(session);
     this.switchTab(id);
     this.renderTabBar();
+    this.requestSaveLayout?.();
+
+    // Install the auto-resume OSC listener before the PTY spawns so the first
+    // prompt's OSC 133 A is caught. Any tab with a `resumeCommand` set runs it
+    // once the shell is ready. Callers that don't want this just omit the field.
+    if (session.resumeCommand) {
+      this.setupAutoResume(session, terminal);
+    }
 
     // Defer PTY spawn until DOM is laid out so fitAddon gets correct dimensions
     setTimeout(() => {
+      // Abort if the session was destroyed while waiting (e.g. openTabOrView
+      // destroy-and-recreate flow replaces a default tab during this 100ms window)
+      if (!this.sessions.some((s) => s.id === session.id)) return;
+
       try {
         fitAddon.fit();
       } catch {
@@ -576,7 +348,7 @@ export class TerminalTabManager {
       }
 
       try {
-        pty.spawn(this.settings.shellPath, this.cwd, cols, rows);
+        pty.spawn(this.settings.shellPath, sessionCwd, cols, rows);
       } catch (err) {
         const message = err instanceof Error ? err.message : "unknown error";
         console.error("Terminal: failed to spawn shell", err);
@@ -595,7 +367,6 @@ export class TerminalTabManager {
       });
 
       pty.onExit(() => {
-        session.pinned = false;
         this.closeTab(session.id);
       });
     }, 100);
@@ -626,6 +397,7 @@ export class TerminalTabManager {
 
     this.renderTabBar();
     this.onActiveChange?.();
+    this.requestSaveLayout?.();
   }
 
   closeTab(id: string): void {
@@ -633,14 +405,13 @@ export class TerminalTabManager {
     if (idx === -1) return;
 
     const session = this.sessions[idx];
-    if (session.pinned) return;
 
-    for (const d of session.parserDisposables) d.dispose();
-    session.parserDisposables = [];
+    // Capture for recents BEFORE destroying (serialize needs a live xterm)
+    this.onSessionClose?.(this.captureSession(session));
+
     session.pty.kill();
     session.terminal.dispose();
     session.containerEl.remove();
-    session.dragLabel.remove();
     this.sessions.splice(idx, 1);
 
     // Switch to adjacent tab if we closed the active one
@@ -653,15 +424,13 @@ export class TerminalTabManager {
       }
     }
 
-    if (this.sessions.length === 0) {
-      sessionCounter = 0;
-      if (this.onTabsEmpty) {
-        this.onTabsEmpty();
-        return;
-      }
+    if (this.sessions.length === 0 && this.onTabsEmpty) {
+      this.onTabsEmpty();
+      return;
     }
 
     this.renderTabBar();
+    this.requestSaveLayout?.();
   }
 
   fitActive(): void {
@@ -683,18 +452,41 @@ export class TerminalTabManager {
     return this.sessions;
   }
 
-  destroyAll(): void {
+  /**
+   * Serialize all sessions into a form suitable for TerminalView.getState().
+   * Buffer serialization is gated on the persistBuffer setting.
+   */
+  serializeSessions(): SavedTab[] {
+    return this.sessions.map((s) => this.captureSession(s));
+  }
+
+  /** Index of the currently active session (0-based), or -1 if none. */
+  getActiveIndex(): number {
+    return this.sessions.findIndex((s) => s.id === this.activeId);
+  }
+
+  /** Activate a session by its position in the sessions array. */
+  switchToIndex(index: number): void {
+    if (index < 0 || index >= this.sessions.length) return;
+    this.switchTab(this.sessions[index].id);
+  }
+
+  /**
+   * Destroy all sessions. Pushes each to onSessionClose (recents) by default.
+   * Pass `saveToRecents: false` when replacing tabs with restored state
+   * (e.g. setState after onOpen's default-tab creation) to avoid polluting recents.
+   */
+  destroyAll(saveToRecents = true): void {
     for (const session of this.sessions) {
-      for (const d of session.parserDisposables) d.dispose();
-      session.parserDisposables = [];
+      if (saveToRecents) {
+        this.onSessionClose?.(this.captureSession(session));
+      }
       session.pty.kill();
       session.terminal.dispose();
       session.containerEl.remove();
-      session.dragLabel.remove();
     }
     this.sessions = [];
     this.activeId = null;
-    sessionCounter = 0;
   }
 
   private notifyCompletion(session: TerminalSession, exitCode: number): void {
@@ -722,6 +514,7 @@ export class TerminalTabManager {
       const newName = input.value.trim() || session.name;
       session.name = newName;
       this.renderTabBar();
+      this.requestSaveLayout?.();
     };
 
     input.addEventListener("blur", commit);
@@ -755,17 +548,6 @@ export class TerminalTabManager {
       this.renameTab(sessionId, labelEl);
     });
 
-    // Pin / Unpin option
-    const pinItem = menu.createDiv({
-      cls: "terminal-ctx-item",
-      text: session.pinned ? "Unpin" : "Pin",
-    });
-    pinItem.addEventListener("click", () => {
-      session.pinned = !session.pinned;
-      this.renderTabBar();
-      menu.remove();
-    });
-
     // Color submenu
     menu.createDiv({ cls: "terminal-ctx-item terminal-ctx-color-label", text: "Color" });
     const colorRow = menu.createDiv({ cls: "terminal-ctx-color-row" });
@@ -784,6 +566,7 @@ export class TerminalTabManager {
       swatch.addEventListener("click", () => {
         session.color = c.value;
         this.renderTabBar();
+        this.requestSaveLayout?.();
         menu.remove();
       });
     }
@@ -801,29 +584,13 @@ export class TerminalTabManager {
   }
 
   updateBackgroundColor(): void {
-    const theme = resolveTerminalTheme(this.settings, this.themeRegistry);
-    for (const session of this.sessions) {
-      session.terminal.options.theme = theme;
+    const theme = getTheme(this.settings.theme);
+    if (this.settings.backgroundColor) {
+      theme.background = this.settings.backgroundColor;
     }
-  }
-
-  /** Re-apply the full theme to all sessions (used when Obsidian switches dark/light). */
-  updateTheme(): void {
-    const theme = resolveTerminalTheme(this.settings, this.themeRegistry);
-    const isDark = isObsidianDark();
     for (const session of this.sessions) {
-      session.terminal.options.theme = theme;
-
-      // Notify child apps that opted into Mode 2031 color-scheme-change updates
-      if (session.mode2031) {
-        const mode = isDark ? 1 : 2; // 1 = dark, 2 = light
-        session.pty.write(`${ESC}[?997;${mode}n`);
-      }
+      session.terminal.options.theme = { ...session.terminal.options.theme, background: theme.background };
     }
-  }
-
-  updateCopyOnSelect(): void {
-    // no-op: onSelectionChange listeners read this.settings.copyOnSelect at call time
   }
 
   private renderTabBar(): void {
@@ -831,17 +598,13 @@ export class TerminalTabManager {
 
     for (const session of this.sessions) {
       const tab = this.tabBarEl.createDiv({
-        cls: `terminal-tab${session.id === this.activeId ? " active" : ""}${session.pinned ? " terminal-tab--pinned" : ""}`,
+        cls: `terminal-tab${session.id === this.activeId ? " active" : ""}`,
       });
 
       // Apply tab color as left border + active highlight
       if (session.color) {
         tab.style.borderLeft = `3px solid ${session.color}`;
         tab.style.setProperty("--tab-accent", session.color);
-      }
-
-      if (session.pinned) {
-        tab.createSpan({ cls: "terminal-tab-pin-icon", text: "\u{1F512}" });
       }
 
       const label = tab.createSpan({ cls: "terminal-tab-label", text: session.name });
@@ -852,56 +615,11 @@ export class TerminalTabManager {
         this.showTabContextMenu(e, session.id, label);
       });
 
-      if (!session.pinned) {
-        const closeBtn = tab.createSpan({ cls: "terminal-tab-close", text: "\u00d7" });
-        closeBtn.addEventListener("click", (e) => {
-          e.stopPropagation();
-          this.closeTab(session.id);
-        });
-      }
-
-      if (this.sessions.length > 1) {
-        tab.draggable = true;
-
-        tab.addEventListener("dragstart", (e) => {
-          this.dragSrcId = session.id;
-          tab.classList.add("dragging");
-          e.dataTransfer?.setDragImage(tab, 0, 0);
-        });
-
-        tab.addEventListener("dragend", () => {
-          this.dragSrcId = null;
-          tab.classList.remove("dragging");
-          this.tabBarEl.querySelectorAll(".drag-over").forEach((el) =>
-            el.classList.remove("drag-over")
-          );
-        });
-
-        tab.addEventListener("dragover", (e) => {
-          e.preventDefault();
-          if (this.dragSrcId && this.dragSrcId !== session.id) {
-            tab.classList.add("drag-over");
-          }
-        });
-
-        tab.addEventListener("dragleave", () => {
-          tab.classList.remove("drag-over");
-        });
-
-        tab.addEventListener("drop", (e) => {
-          e.preventDefault();
-          tab.classList.remove("drag-over");
-          if (!this.dragSrcId || this.dragSrcId === session.id) return;
-
-          const srcIndex = this.sessions.findIndex((s) => s.id === this.dragSrcId);
-          const dstIndex = this.sessions.findIndex((s) => s.id === session.id);
-          if (srcIndex === -1 || dstIndex === -1) return;
-
-          const [moved] = this.sessions.splice(srcIndex, 1);
-          this.sessions.splice(dstIndex, 0, moved);
-          this.renderTabBar();
-        });
-      }
+      const closeBtn = tab.createSpan({ cls: "terminal-tab-close", text: "\u00d7" });
+      closeBtn.addEventListener("click", (e) => {
+        e.stopPropagation();
+        this.closeTab(session.id);
+      });
     }
 
     const addBtn = this.tabBarEl.createDiv({ cls: "terminal-new-tab", text: "+" });

--- a/src/terminal-tab-manager.ts
+++ b/src/terminal-tab-manager.ts
@@ -1,13 +1,14 @@
-import { Notice } from "obsidian";
+import { Notice, type App, FileSystemAdapter } from "obsidian";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { SerializeAddon } from "@xterm/addon-serialize";
 import type { IDisposable } from "@xterm/xterm";
 import { PtyManager } from "./pty-manager";
-import { getTheme } from "./themes";
+import { getTheme, isObsidianDark } from "./themes";
 import { mixHex } from "./color-utils";
 import { findTabColor, DEFAULT_TINT_STRENGTH } from "./tab-colors";
+import { ThemeRegistry } from "./theme-registry";
 import type { TerminalPluginSettings } from "./settings";
 import type { NotificationSound } from "./settings";
 import type { BinaryManager } from "./binary-manager";
@@ -56,15 +57,6 @@ function matchesShortcut(e: KeyboardEvent, shortcut: string): boolean {
   );
 }
 
-const SEARCH_DECORATIONS = {
-  matchBackground: "#ffff00",
-  matchBorder: "#ffff00",
-  matchOverviewRuler: "#ffff00",
-  activeMatchBackground: "#ff6600",
-  activeMatchBorder: "#ff0000",
-  activeMatchColorOverviewRuler: "#ff0000",
-} as const;
-
 export interface TerminalSession {
   id: string;
   name: string;
@@ -78,6 +70,12 @@ export interface TerminalSession {
   cwd: string;
   /** Command to re-run on restore (e.g. "claude --resume <uuid>"). */
   resumeCommand?: string;
+  /** Disposables for parser/event handlers — cleaned up on close. */
+  parserDisposables: IDisposable[];
+  /** Mode 2031 state for terminal color queries. */
+  mode2031: boolean;
+  /** Whether this tab is pinned and cannot be closed. */
+  pinned: boolean;
 }
 
 /** Options for restoring a tab from persisted state (via setState). */
@@ -326,7 +324,6 @@ function extractDropPath(e: DragEvent, app: App): string | null {
   return null;
 }
 
->>>>>>> 9d8db06 (feat: per-tab color tint with editable palette)
 export class TerminalTabManager {
   private sessions: TerminalSession[] = [];
   private activeId: string | null = null;
@@ -336,6 +333,7 @@ export class TerminalTabManager {
   private cwd: string;
   private pluginDir: string;
   private binaryManager: BinaryManager;
+  private themeRegistry: ThemeRegistry;
   private onActiveChange?: () => void;
   private onTabsEmpty?: () => void;
   private requestSaveLayout?: () => void;
@@ -350,6 +348,7 @@ export class TerminalTabManager {
     cwd: string,
     pluginDir: string,
     binaryManager: BinaryManager,
+    themeRegistry: ThemeRegistry,
     onActiveChange?: () => void,
     onTabsEmpty?: () => void,
     requestSaveLayout?: () => void,
@@ -361,6 +360,7 @@ export class TerminalTabManager {
     this.cwd = cwd;
     this.pluginDir = pluginDir;
     this.binaryManager = binaryManager;
+    this.themeRegistry = themeRegistry;
     this.onActiveChange = onActiveChange;
     this.onTabsEmpty = onTabsEmpty;
     this.requestSaveLayout = requestSaveLayout;
@@ -515,6 +515,9 @@ export class TerminalTabManager {
       color: opts?.color ?? "",
       cwd: sessionCwd,
       resumeCommand: opts?.resumeCommand,
+      parserDisposables: [],
+      mode2031: false,
+      pinned: false,
     };
     this.sessions.push(session);
     this.switchTab(id);

--- a/src/terminal-tab-manager.ts
+++ b/src/terminal-tab-manager.ts
@@ -31,7 +31,7 @@ export interface TerminalSession {
   color: string;
   /** Working directory the shell was spawned in. */
   cwd: string;
-  /** Reserved for Stage C: command to re-run on restore (e.g. "claude --resume <uuid>"). */
+  /** Command to re-run on restore (e.g. "claude --resume <uuid>"). */
   resumeCommand?: string;
 }
 
@@ -591,6 +591,10 @@ export class TerminalTabManager {
     for (const session of this.sessions) {
       session.terminal.options.theme = { ...session.terminal.options.theme, background: theme.background };
     }
+  }
+
+  updateCopyOnSelect(): void {
+    // no-op: onSelectionChange listeners read this.settings.copyOnSelect at call time
   }
 
   private renderTabBar(): void {

--- a/src/terminal-view.ts
+++ b/src/terminal-view.ts
@@ -68,6 +68,7 @@ export class TerminalView extends ItemView {
       cwd,
       pluginDir,
       this.plugin.binaryManager,
+      this.plugin.themeRegistry,
       undefined,
       () => this.leaf.detach(),
       () => { void this.app.workspace.requestSaveLayout(); },

--- a/src/terminal-view.ts
+++ b/src/terminal-view.ts
@@ -1,13 +1,20 @@
-import { FileSystemAdapter, ItemView, WorkspaceLeaf } from "obsidian";
+import { FileSystemAdapter, ItemView, WorkspaceLeaf, type ViewStateResult } from "obsidian";
 import { VIEW_TYPE_TERMINAL } from "./constants";
 import { TerminalTabManager } from "./terminal-tab-manager";
+import { pushRecentSession } from "./recent-sessions";
 import type TerminalPlugin from "./main";
+import type { SavedViewState } from "./session-state";
 
 export class TerminalView extends ItemView {
   private plugin: TerminalPlugin;
   private tabManager: TerminalTabManager | null = null;
   private resizeObserver: ResizeObserver | null = null;
   private resizeTimer: ReturnType<typeof setTimeout> | null = null;
+  /**
+   * State passed to setState() before onOpen() has constructed the tab manager.
+   * Applied in onOpen() once the manager is ready.
+   */
+  private pendingState: SavedViewState | null = null;
 
   constructor(leaf: WorkspaceLeaf, plugin: TerminalPlugin) {
     super(leaf);
@@ -55,18 +62,26 @@ export class TerminalView extends ItemView {
 
     // Create tab manager and first terminal
     this.tabManager = new TerminalTabManager(
-      this.plugin.app,
       tabBarEl,
       terminalHostEl,
       this.plugin.settings,
       cwd,
       pluginDir,
       this.plugin.binaryManager,
-      this.plugin.themeRegistry,
       undefined,
-      () => this.leaf.detach()
+      () => this.leaf.detach(),
+      () => { void this.app.workspace.requestSaveLayout(); },
+      (tab) => { void pushRecentSession(this.plugin, tab); }
     );
-    this.tabManager.createTab();
+
+    if (this.pendingState) {
+      // setState already fired (edge case) — apply its state
+      this.applyPendingState();
+    } else if (!parseSavedViewState(this.leaf.getViewState().state)) {
+      // No saved state incoming — create a default tab.
+      // (If saved state IS incoming, setState will fire next and own tab creation.)
+      this.tabManager.createTab();
+    }
 
     // Resize observer for auto-fit
     this.resizeObserver = new ResizeObserver(() => {
@@ -76,6 +91,18 @@ export class TerminalView extends ItemView {
       }, 50);
     });
     this.resizeObserver.observe(terminalHostEl);
+
+    // Periodic save: every 10s, if terminal output happened since the last check,
+    // trigger requestSaveLayout. This replaces per-chunk save calls that caused
+    // input lag under heavy output (e.g. Claude streaming). Quit still flushes
+    // via main.ts's workspace.on("quit") → requestSaveLayout.run().
+    this.registerInterval(
+      window.setInterval(() => {
+        if (this.tabManager?.consumeOutputDirty()) {
+          void this.app.workspace.requestSaveLayout();
+        }
+      }, 10000)
+    );
   }
 
   // eslint-disable-next-line @typescript-eslint/require-await -- onClose must satisfy Promise<void> return type of parent ItemView; no actual async work here
@@ -98,11 +125,67 @@ export class TerminalView extends ItemView {
     this.tabManager?.updateBackgroundColor();
   }
 
-  updateTheme(): void {
-    this.tabManager?.updateTheme();
+  getState(): Record<string, unknown> {
+    if (!this.tabManager) {
+      // Before onOpen runs (or after onClose): hand back any pending state we still have
+      return this.pendingState
+        ? { tabs: this.pendingState.tabs, activeIndex: this.pendingState.activeIndex }
+        : {};
+    }
+    const state: SavedViewState = {
+      tabs: this.tabManager.serializeSessions(),
+      activeIndex: this.tabManager.getActiveIndex(),
+    };
+    return { ...state };
   }
 
-  updateCopyOnSelect(): void {
-    this.tabManager?.updateCopyOnSelect();
+  // eslint-disable-next-line @typescript-eslint/require-await -- async required by parent View.setState signature; restore is synchronous
+  async setState(state: unknown, result: ViewStateResult): Promise<void> {
+    result.history = false;
+    const parsed = parseSavedViewState(state);
+    if (!parsed) return;
+
+    this.pendingState = parsed;
+    if (!this.tabManager) return;
+
+    // setState is authoritative: if any tabs exist (e.g. a default tab created
+    // by onOpen before the getViewState peek detected incoming state), replace them.
+    // Pass saveToRecents=false — the default tab had no user activity.
+    if (this.tabManager.getSessions().length > 0) {
+      this.tabManager.destroyAll(false);
+    }
+    this.applyPendingState();
   }
+
+  private applyPendingState(): void {
+    const state = this.pendingState;
+    if (!state || !this.tabManager) return;
+    this.pendingState = null;
+
+    for (const tab of state.tabs) {
+      this.tabManager.createTab({
+        name: tab.name,
+        color: tab.color,
+        cwd: tab.cwd,
+        bufferSerial: tab.bufferSerial,
+        resumeCommand: tab.resumeCommand,
+      });
+    }
+
+    if (state.activeIndex >= 0) {
+      this.tabManager.switchToIndex(state.activeIndex);
+    }
+  }
+}
+
+/**
+ * Validate and narrow an unknown state value to SavedViewState.
+ * Returns null for missing, malformed, or empty state.
+ */
+function parseSavedViewState(state: unknown): SavedViewState | null {
+  if (!state || typeof state !== "object") return null;
+  const s = state as Partial<SavedViewState>;
+  if (!Array.isArray(s.tabs) || s.tabs.length === 0) return null;
+  const activeIndex = typeof s.activeIndex === "number" ? s.activeIndex : 0;
+  return { tabs: s.tabs, activeIndex };
 }

--- a/src/terminal-view.ts
+++ b/src/terminal-view.ts
@@ -125,6 +125,10 @@ export class TerminalView extends ItemView {
     this.tabManager?.updateBackgroundColor();
   }
 
+  updateCopyOnSelect(): void {
+    this.tabManager?.updateCopyOnSelect();
+  }
+
   getState(): Record<string, unknown> {
     if (!this.tabManager) {
       // Before onOpen runs (or after onClose): hand back any pending state we still have

--- a/src/theme-registry.ts
+++ b/src/theme-registry.ts
@@ -1,137 +1,72 @@
-import { Notice } from "obsidian";
 import type { ITheme } from "@xterm/xterm";
-import { BUILTIN_THEMES, isObsidianDark } from "./themes";
-
-const USER_THEMES_FILENAME = "themes.json";
-const HEX6_RE = /^#[0-9a-fA-F]{6}$/;
+import { BUILTIN_THEMES } from "./themes";
 
 /**
- * Owns the merged color-scheme catalog (built-ins + user overrides) and
- * loads/validates the user-editable themes.json file from the plugin folder.
- *
- * Load errors never block the plugin — bad entries are skipped with a
- * console warning, and a single Notice summarises failures to the user.
+ * ThemeRegistry loads built-in themes plus optional themes.json from the plugin folder.
+ * Users can extend or override built-in themes at runtime.
  */
 export class ThemeRegistry {
-  private merged: Record<string, ITheme> = { ...BUILTIN_THEMES };
-  private userLoadErrors: string[] = [];
-  private readonly path: typeof import("path");
+  private themes: Record<string, ITheme>;
+  private pluginDir: string;
+  private loadErrors: string[] = [];
 
-  constructor(private pluginDir: string) {
-    this.path = window.require("path") as typeof import("path");
+  constructor(pluginDir: string) {
+    this.pluginDir = pluginDir;
+    this.themes = { ...BUILTIN_THEMES };
+  }
+
+  async load(): Promise<void> {
+    const path = window.require("path") as typeof import("path");
+    const fs = (window.require("fs") as typeof import("fs")).promises;
+
+    const themesPath = path.join(this.pluginDir, "themes.json");
+    try {
+      const content = await fs.readFile(themesPath, "utf-8");
+      const data = JSON.parse(content) as Record<string, ITheme>;
+      // Merge user themes with built-ins (user can override)
+      this.themes = { ...this.themes, ...data };
+    } catch (err) {
+      // themes.json doesn't exist or can't be parsed — just use built-ins
+      if (err instanceof Error && !err.message.includes("ENOENT")) {
+        this.loadErrors.push(`Failed to load themes.json: ${err.message}`);
+      }
+    }
   }
 
   /**
-   * Re-read themes.json from the plugin folder and rebuild the merged catalog.
-   * Safe to call repeatedly (e.g. from a "Reload themes" button). Each call
-   * resets to built-ins before merging, so removing an override from the file
-   * correctly resurfaces the built-in.
+   * Get a theme by name. Returns a clone so mutations don't affect the registry.
    */
-  async load(): Promise<void> {
-    this.merged = { ...BUILTIN_THEMES };
-    this.userLoadErrors = [];
-
-    const fs = window.require("fs/promises") as typeof import("fs/promises");
-    const path = this.getUserFilePath();
-
-    let raw: string;
-    try {
-      raw = await fs.readFile(path, "utf-8");
-    } catch (err: unknown) {
-      const code = (err as NodeJS.ErrnoException)?.code;
-      if (code === "ENOENT") return; // No user file — built-ins only, silent.
-      this.reportFileError(`Lean Terminal: Could not read ${USER_THEMES_FILENAME} (see console).`, err);
-      return;
-    }
-
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(raw);
-    } catch (err: unknown) {
-      this.reportFileError(`Lean Terminal: ${USER_THEMES_FILENAME} is not valid JSON (see console).`, err);
-      return;
-    }
-
-    if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
-      this.reportFileError(
-        `Lean Terminal: ${USER_THEMES_FILENAME} must be a JSON object keyed by theme name.`,
-        parsed
-      );
-      return;
-    }
-
-    for (const [name, entry] of Object.entries(parsed as Record<string, unknown>)) {
-      const theme = this.validateEntry(name, entry);
-      if (theme) this.merged[name] = theme;
-    }
-
-    if (this.userLoadErrors.length > 0) {
-      new Notice(
-        `Lean Terminal: ${this.userLoadErrors.length} custom theme(s) failed to load - see console for details.`
-      );
-    }
-  }
-
-  getNames(): string[] {
-    return Object.keys(this.merged).sort();
-  }
-
   get(name: string): ITheme {
-    if (name === "system") {
-      const resolved = isObsidianDark() ? "obsidian-dark" : "obsidian-light";
-      return { ...(this.merged[resolved] ?? BUILTIN_THEMES["obsidian-dark"]) };
-    }
-    return { ...(this.merged[name] ?? BUILTIN_THEMES["obsidian-dark"]) };
+    const theme = this.themes[name] || this.themes["obsidian-dark"];
+    // Return a shallow clone so callers can mutate without side effects
+    return { ...theme };
   }
 
-  getUserFilePath(): string {
-    return this.path.join(this.pluginDir, USER_THEMES_FILENAME);
+  /**
+   * Get the list of available theme names.
+   */
+  list(): string[] {
+    return Object.keys(this.themes);
   }
 
-  /** Absolute path to the plugin folder — used to open the folder in the OS file manager from settings. */
+  /**
+   * Alias for list() — expected by settings.ts
+   */
+  getNames(): string[] {
+    return this.list();
+  }
+
+  /**
+   * Return the plugin directory.
+   */
   getPluginDir(): string {
     return this.pluginDir;
   }
 
   /**
-   * Returns mixed content: user-facing sentences (from file errors) and internal
-   * [lean-terminal] log-style strings (from entry validation). Callers typically
-   * only need `.length > 0` to detect "had errors"—don't display these strings
-   * directly to users since file-level errors already fired their own Notice.
+   * Return any errors that occurred during load.
    */
-  getUserLoadErrors(): readonly string[] {
-    return this.userLoadErrors;
-  }
-
-  private validateEntry(name: string, entry: unknown): ITheme | null {
-    if (entry === null || typeof entry !== "object" || Array.isArray(entry)) {
-      this.recordEntryError(name, "entry must be an object");
-      return null;
-    }
-    const e = entry as Record<string, unknown>;
-    if (typeof e.background !== "string" || !HEX6_RE.test(e.background)) {
-      this.recordEntryError(name, "missing or invalid `background` (expected #rrggbb)");
-      return null;
-    }
-    if (typeof e.foreground !== "string" || !HEX6_RE.test(e.foreground)) {
-      this.recordEntryError(name, "missing or invalid `foreground` (expected #rrggbb)");
-      return null;
-    }
-    // Pass through — xterm ITheme fields are all optional strings, so once
-    // background/foreground validate we accept the rest as-is. Bad color
-    // strings for optional fields render as xterm defaults.
-    return entry as ITheme;
-  }
-
-  private reportFileError(userMessage: string, detail: unknown): void {
-    console.warn("[lean-terminal] themes.json load error:", detail);
-    this.userLoadErrors.push(userMessage);
-    new Notice(userMessage);
-  }
-
-  private recordEntryError(name: string, reason: string): void {
-    const msg = `[lean-terminal] themes.json entry "${name}" skipped: ${reason}`;
-    console.warn(msg);
-    this.userLoadErrors.push(msg);
+  getUserLoadErrors(): string[] {
+    return this.loadErrors;
   }
 }

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -287,3 +287,8 @@ export const BUILTIN_THEMES: Record<string, ITheme> = {
 export function isObsidianDark(): boolean {
   return document.body.classList.contains("theme-dark");
 }
+
+/** Get a theme by name, falling back to obsidian-dark if not found. */
+export function getTheme(name: string): ITheme {
+  return BUILTIN_THEMES[name] || BUILTIN_THEMES["obsidian-dark"];
+}

--- a/styles.css
+++ b/styles.css
@@ -473,3 +473,44 @@
   opacity: 0.8;
   flex-shrink: 0;
 }
+
+/* --- Per-tab colored fill ------------------------------------------- */
+/* --tab-accent (hex) and --tab-color-intensity (0..MAX, e.g. 12) come
+   from the tab-manager and drive idle/hover/active fill density. The
+   multiplier (1.5/2.2/2.7) lets users keep the same numeric intensity
+   value while idle/hover/active stay visually distinct. */
+.terminal-tab--colored {
+  background: color-mix(
+    in srgb,
+    var(--tab-accent) calc(var(--tab-color-intensity) * 1.5%),
+    transparent
+  );
+  border-left: 3px solid var(--tab-accent);
+}
+
+.terminal-tab--colored:hover {
+  background: color-mix(
+    in srgb,
+    var(--tab-accent) calc(var(--tab-color-intensity) * 2.2%),
+    var(--background-modifier-hover)
+  );
+}
+
+.terminal-tab--colored.active {
+  background: color-mix(
+    in srgb,
+    var(--tab-accent) calc(var(--tab-color-intensity) * 2.7%),
+    var(--background-primary)
+  );
+}
+
+/* Settings palette swatch chip */
+.lean-color-swatch {
+  display: inline-block;
+  width: 14px;
+  height: 14px;
+  border-radius: 3px;
+  margin-right: 8px;
+  vertical-align: middle;
+  border: 1px solid var(--background-modifier-border);
+}


### PR DESCRIPTION
## Problem

ARM64 Windows users (Snapdragon X, Qualcomm Oryon) get a 404 error when downloading binaries because:

1. \`binary-manager.ts\` constructs the asset name from \`process.arch\` — on Snapdragon: \`node-pty-win32-arm64.zip\`
2. The CI only built \`node-pty-win32-x64.zip\` — the ARM64 zip never existed in releases

## Changes

**\`.github/workflows/build-node-pty.yml\`**
- Add \`windows-arm64\` runner to the build matrix
- Add \`timeout-minutes: 30\` to prevent a hung ARM64 runner from blocking releases

**\`src/binary-manager.ts\`**
- Skip the \`winpty.dll\` existence check on \`win32-arm64\`
- ARM64 Windows uses ConPTY natively; \`winpty.dll\` is only present in \`win32-x64\` prebuilds
- Without this fix, the binary downloads successfully but \`checkInstalled()\` always returns false, leaving users stuck at the download screen

## Supported Platforms After This Change

| Platform | Arch | Runner |
|---|---|---|
| Windows | x64 | windows-latest |
| Windows | arm64 | windows-arm64 (**new**) |
| macOS | arm64 | macos-15 |
| macOS | x64 | macos-15 |
| Linux | x64 | ubuntu-latest |

## Notes

- No plugin code changes beyond the \`winpty.dll\` guard
- The \`windows-arm64\` runner requires GitHub Actions ARM64 runner access (available on GitHub Team/Enterprise plans and many free public repos since 2024)
- \`fail-fast: false\` is already set, so a missing runner won't block x64/macOS/Linux builds

Co-Authored-By: Claude