### PR TITLE
docs: add shields.io badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Lean Terminal
 
+[![GitHub stars](https://img.shields.io/github/stars/sdkasper/lean-obsidian-terminal?logo=obsidian&logoColor=white&color=7C3AED)](https://github.com/sdkasper/lean-obsidian-terminal/stargazers)
+[![Open issues](https://img.shields.io/github/issues/sdkasper/lean-obsidian-terminal?logo=obsidian&logoColor=white&color=7C3AED&label=issues+open)](https://github.com/sdkasper/lean-obsidian-terminal/issues)
+[![Closed issues](https://img.shields.io/github/issues-closed/sdkasper/lean-obsidian-terminal?logo=obsidian&logoColor=white&color=7C3AED&label=issues+closed)](https://github.com/sdkasper/lean-obsidian-terminal/issues?q=is%3Aissue+is%3Aclosed)
+[![Manifest version](https://img.shields.io/github/manifest-json/v/sdkasper/lean-obsidian-terminal?logo=obsidian&logoColor=white&color=7C3AED&label=manifest)](https://github.com/sdkasper/lean-obsidian-terminal/blob/master/manifest.json)
+[![Total downloads](https://img.shields.io/github/downloads/sdkasper/lean-obsidian-terminal/total?logo=obsidian&logoColor=white&color=7C3AED&label=downloads)](https://github.com/sdkasper/lean-obsidian-terminal/releases)
+
 An embedded terminal panel for [Obsidian](https://obsidian.md), powered by [xterm.js](https://xtermjs.org/) and [node-pty](https://github.com/nicedoc/node-pty). Run shell commands directly inside your vault workspace - no external windows needed.
 
 **Desktop only.** Requires Obsidian 1.5.0+.


### PR DESCRIPTION
Adds five live shields.io badges below the title: stars, open issues, closed issues, manifest version, and total downloads.

Co-Authored-By: Claude