### PR TITLE
docs: restyle badges to LeanProductivity brand colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Lean Terminal
 
-[![GitHub stars](https://img.shields.io/github/stars/sdkasper/lean-obsidian-terminal?logo=obsidian&logoColor=white&color=7C3AED)](https://github.com/sdkasper/lean-obsidian-terminal/stargazers)
-[![Open issues](https://img.shields.io/github/issues/sdkasper/lean-obsidian-terminal?logo=obsidian&logoColor=white&color=7C3AED&label=issues+open)](https://github.com/sdkasper/lean-obsidian-terminal/issues)
-[![Closed issues](https://img.shields.io/github/issues-closed/sdkasper/lean-obsidian-terminal?logo=obsidian&logoColor=white&color=7C3AED&label=issues+closed)](https://github.com/sdkasper/lean-obsidian-terminal/issues?q=is%3Aissue+is%3Aclosed)
-[![Manifest version](https://img.shields.io/github/manifest-json/v/sdkasper/lean-obsidian-terminal?logo=obsidian&logoColor=white&color=7C3AED&label=manifest)](https://github.com/sdkasper/lean-obsidian-terminal/blob/master/manifest.json)
-[![Total downloads](https://img.shields.io/github/downloads/sdkasper/lean-obsidian-terminal/total?logo=obsidian&logoColor=white&color=7C3AED&label=downloads)](https://github.com/sdkasper/lean-obsidian-terminal/releases)
+[![GitHub stars](https://img.shields.io/github/stars/sdkasper/lean-obsidian-terminal?logo=obsidian&logoColor=white&style=flat-square&labelColor=1B2631&color=25D0F7)](https://github.com/sdkasper/lean-obsidian-terminal/stargazers)
+[![Open issues](https://img.shields.io/github/issues/sdkasper/lean-obsidian-terminal?logo=obsidian&logoColor=white&style=flat-square&labelColor=1B2631&color=25D0F7&label=issues+open)](https://github.com/sdkasper/lean-obsidian-terminal/issues)
+[![Closed issues](https://img.shields.io/github/issues-closed/sdkasper/lean-obsidian-terminal?logo=obsidian&logoColor=white&style=flat-square&labelColor=1B2631&color=25D0F7&label=issues+closed)](https://github.com/sdkasper/lean-obsidian-terminal/issues?q=is%3Aissue+is%3Aclosed)
+[![Manifest version](https://img.shields.io/github/manifest-json/v/sdkasper/lean-obsidian-terminal?logo=obsidian&logoColor=white&style=flat-square&labelColor=1B2631&color=25D0F7&label=manifest)](https://github.com/sdkasper/lean-obsidian-terminal/blob/master/manifest.json)
+[![Total downloads](https://img.shields.io/github/downloads/sdkasper/lean-obsidian-terminal/total?logo=obsidian&logoColor=white&style=flat-square&labelColor=1B2631&color=25D0F7&label=downloads)](https://github.com/sdkasper/lean-obsidian-terminal/releases)
 
 An embedded terminal panel for [Obsidian](https://obsidian.md), powered by [xterm.js](https://xtermjs.org/) and [node-pty](https://github.com/nicedoc/node-pty). Run shell commands directly inside your vault workspace - no external windows needed.
 


### PR DESCRIPTION
Replaces Obsidian purple with LP brand colors:

- Value background: Vivid Sky Blue `#25D0F7` (primary LP accent)
- Label background: Gunmetal `#1B2631` (dark-mode-first anchor)
- Style: `flat-square` (clean, technical aesthetic)

Co-Authored-By: Claude