### PR TITLE
feat: Clickable [[wikilinks]] and obsidian:// URI support

### DIFF
--- a/.planning/phases/02-code-review-lineHeight/REVIEW.md
+++ b/.planning/phases/02-code-review-lineHeight/REVIEW.md
@@ -1,0 +1,239 @@
+---
+phase: 02-code-review-lineHeight
+reviewed: 2026-05-07T00:00:00Z
+depth: standard
+files_reviewed: 2
+files_reviewed_list:
+  - src/settings.ts
+  - src/terminal-tab-manager.ts
+findings:
+  critical: 2
+  warning: 2
+  info: 1
+  total: 5
+status: issues_found
+---
+
+# Phase 02: Code Review - lineHeight Feature Implementation
+
+**Reviewed:** 2026-05-07
+**Depth:** standard
+**Files Reviewed:** 2
+**Status:** ISSUES FOUND
+
+## Summary
+
+The lineHeight feature implementation adds support for xterm.js's lineHeight option (multiplier, default 1.0) to expose terminal line spacing in plugin settings. The feature correctly:
+- Adds `lineHeight: number` field to TerminalPluginSettings interface
+- Sets appropriate default value (1.0, matching xterm.js)
+- Passes the setting to Terminal constructor in buildXterm()
+- Implements slider UI with reasonable range (1.0-2.0)
+
+However, the implementation has **critical gaps**:
+1. **No update mechanism for existing terminals** when the setting changes
+2. **Slider starting value assertion issue** due to floating-point step misalignment with bounds
+3. **Inconsistency with fontSize/fontFamily handling** (those also lack update mechanisms)
+4. **Missing validation on lower bound** (xterm.js rejects values < 1, UI allows 1.0 but with step precision concerns)
+
+---
+
+## Critical Issues
+
+### CR-01: Missing Update Handler for lineHeight Changes
+
+**File:** `src/settings.ts:451-463` and `src/main.ts` (no handler exists)
+
+**Issue:** 
+When a user changes the lineHeight slider in Settings, the value is saved to `this.plugin.settings.lineHeight` and persisted via `saveSettings()`. However, **existing active terminal tabs do not reflect the change**. They continue using the old lineHeight value until they are closed and reopened.
+
+This is a **behavioral inconsistency vs. other terminal options**:
+- `backgroundColor`, `theme`, `cursorBlink` have no live-update handlers either (same bug)
+- However, `copyOnSelect` **does** have an update handler (`updateCopyOnSelect()` in main.ts)
+
+The xterm.js Terminal object supports dynamic updates: `terminal.options.lineHeight = newValue` will take immediate effect.
+
+**Evidence:** 
+- `buildXterm()` (line 406) applies the lineHeight: `lineHeight: this.settings.lineHeight`
+- Settings UI (line 454-462) has no callback that triggers tab updates
+- `main.ts` has no `updateLineHeight()` method (only `updateTheme()`, `updateCopyOnSelect()`, `updateTerminalBackgrounds()`, `updateIcon()`)
+- fontSize/fontFamily have the same gap, but xterm.js Terminal does **not** support dynamic fontSize/fontFamily changes via `.options`, so those cannot be live-updated (this is a design limitation of xterm.js, not a bug)
+- **lineHeight CAN be changed dynamically** (per xterm.js OptionsService.ts validation logic)
+
+**Fix:**
+Add an `updateLineHeight()` method to TerminalPlugin and call it from the slider's onChange handler:
+
+```typescript
+// In src/main.ts, add method:
+updateLineHeight(): void {
+  const leaves = this.app.workspace.getLeavesOfType(VIEW_TYPE_TERMINAL);
+  for (const leaf of leaves) {
+    const view = leaf.view as TerminalView;
+    const tabMgr = view.getTabManager();
+    if (tabMgr) {
+      for (const session of tabMgr.getSessions()) {
+        session.terminal.options.lineHeight = this.settings.lineHeight;
+      }
+    }
+  }
+}
+
+// In src/settings.ts, line 459, modify the onChange:
+.onChange(async (value) => {
+  this.plugin.settings.lineHeight = value;
+  await this.plugin.saveSettings();
+  this.plugin.updateLineHeight();  // Add this line
+})
+```
+
+---
+
+### CR-02: Slider Lower Bound Precision Issue with 0.05 Step
+
+**File:** `src/settings.ts:454-457`
+
+**Issue:**
+The slider is configured as:
+```typescript
+.setLimits(1.0, 2.0, 0.05)
+.setValue(this.plugin.settings.lineHeight)
+```
+
+With a step of 0.05, iterating from 1.0:
+- 1.0 → 1.05 → 1.10 → 1.15 → ... → 2.0
+
+This is mathematically sound. **However**, floating-point arithmetic in JavaScript can cause the `setValue()` call to fail silently or produce unexpected behavior if `lineHeight` (loaded from storage) is not exactly representable as `1.0 + 0.05*N`.
+
+**Risk:** If a user's stored `lineHeight` is corrupted or set to a non-aligned value (e.g., 1.003 due to a plugin update or manual JSON edit), the slider will not display correctly and xterm.js will reject it:
+
+```typescript
+// From xterm.js OptionsService.ts validation:
+case 'lineHeight':
+  if (value < 1) {
+    throw new Error(`${key} cannot be less than 1, value: ${value}`);
+  }
+```
+
+Although 1.003 > 1, xterm.js may have additional (undocumented) constraints. The UI provides no feedback if setValue fails to bind the value to the slider.
+
+**Fix:**
+Add explicit validation to clamp and round to valid step increments:
+
+```typescript
+new Setting(containerEl)
+  .setName("Line height")
+  .setDesc("Terminal line height multiplier (default 1.0)")
+  .addSlider((slider) => {
+    // Clamp and round to nearest 0.05 increment
+    const normalized = Math.max(1.0, Math.min(2.0, Math.round(this.plugin.settings.lineHeight * 20) / 20));
+    slider
+      .setLimits(1.0, 2.0, 0.05)
+      .setValue(normalized)
+      .setDynamicTooltip()
+      .onChange(async (value) => {
+        this.plugin.settings.lineHeight = value;
+        await this.plugin.saveSettings();
+        this.plugin.updateLineHeight();
+      });
+  });
+```
+
+The `* 20 / 20` converts 0.05 steps to integer increments (20 steps = 1.0 range), rounding to nearest integer, then back.
+
+---
+
+## Warnings
+
+### WR-01: Inconsistent Setting Update Pattern
+
+**File:** `src/settings.ts` appearance section (lines 426-463)
+
+**Issue:**
+The lineHeight change handler follows the old pattern used by fontSize and fontFamily (no live update). This is inconsistent with the newer pattern used by `copyOnSelect` (line 356-361) which calls `this.plugin.updateCopyOnSelect()`.
+
+While this is not a correctness bug (fontSize/fontFamily cannot be live-updated in xterm.js), it creates a confusing maintenance burden:
+- Users will expect lineHeight to update immediately like copyOnSelect does
+- Code reviewers will wonder why some settings update live and others don't
+- Future developers may copy this pattern for other dynamically-updatable settings
+
+**Fix:** Add the `updateLineHeight()` call as specified in CR-01. This aligns the pattern with copyOnSelect and documents the intent.
+
+---
+
+### WR-02: Missing Input Validation in DEFAULT_SETTINGS
+
+**File:** `src/settings.ts:60`
+
+**Issue:**
+DEFAULT_SETTINGS.lineHeight is set to 1.0, but there is no runtime guard or type-checking to ensure that loaded settings always contain a valid `lineHeight` value. If a user's vault settings JSON is manually edited or corrupted, invalid values (negative, > 2.0, NaN) could be loaded and passed to xterm.js, causing runtime errors.
+
+The xterm.js OptionsService will throw an Error if `lineHeight < 1` (per source), but the plugin does not catch or handle this gracefully.
+
+**Fix:**
+Add validation in onload() or loadSettings():
+
+```typescript
+async onload(): Promise<void> {
+  await this.loadSettings();
+  
+  // Validate lineHeight
+  if (typeof this.settings.lineHeight !== 'number' || this.settings.lineHeight < 1 || this.settings.lineHeight > 2) {
+    this.settings.lineHeight = DEFAULT_SETTINGS.lineHeight;
+    await this.saveSettings();
+  }
+  
+  // ... rest of onload
+}
+```
+
+---
+
+## Info
+
+### IN-01: Lack of Test Coverage for lineHeight Feature
+
+**File:** `src/settings.ts`, `src/terminal-tab-manager.ts` (no tests exist)
+
+**Issue:**
+The lineHeight feature is not covered by any test file in `src/`. The 7 existing test files (color-utils, theme-registry, wikilink-autocomplete, etc.) do not include settings or terminal-tab-manager tests.
+
+This means:
+- No regression tests if future refactoring changes the lineHeight initialization
+- No verification that the slider UI properly binds the value
+- No integration tests for the update handler (once fixed per CR-01)
+
+**Fix:**
+Add test file `src/terminal-tab-manager.test.ts` covering:
+```typescript
+describe('buildXterm', () => {
+  it('should apply lineHeight setting to Terminal constructor', () => {
+    const settings = { ...DEFAULT_SETTINGS, lineHeight: 1.5 };
+    const terminal = tabManager.buildXterm(containerEl);
+    expect(terminal.terminal.options.lineHeight).toBe(1.5);
+  });
+});
+
+describe('TerminalSettingTab', () => {
+  it('should clamp lineHeight to valid range', () => {
+    // Verify setValue(0.5) normalizes to 1.0
+    // Verify setValue(2.5) normalizes to 2.0
+  });
+});
+```
+
+---
+
+## Summary
+
+| Category | Count | Severity |
+|----------|-------|----------|
+| Critical | 2 | BLOCKER: Missing update handler + slider precision issue |
+| Warning | 2 | Consistency and validation gaps |
+| Info | 1 | Test coverage gap |
+
+**Recommended Action:** Address CR-01 (missing update handler) and CR-02 (slider precision) before shipping. WR-01 and WR-02 should be fixed in follow-up PRs.
+
+---
+
+_Reviewed: 2026-05-07_  
+_Reviewer: Claude (gsd-code-reviewer)_  
+_Depth: standard_

--- a/src/binary-manager.ts
+++ b/src/binary-manager.ts
@@ -148,13 +148,19 @@ export class BinaryManager {
 
       // Extract zip using platform-native tools
       if (platform === "win32") {
-        this.childProcess.execSync(
-          `powershell -NoProfile -Command "Expand-Archive -Path '${tmpZip}' -DestinationPath '${this.nodePtyDir}' -Force"`,
+        this.childProcess.execFileSync(
+          "powershell",
+          [
+            "-NoProfile",
+            "-Command",
+            `Expand-Archive -Path '${tmpZip.replace(/'/g, "''")}' -DestinationPath '${this.nodePtyDir.replace(/'/g, "''")}' -Force`,
+          ],
           { timeout: 30000 }
         );
       } else {
-        this.childProcess.execSync(
-          `unzip -o "${tmpZip}" -d "${this.nodePtyDir}"`,
+        this.childProcess.execFileSync(
+          "unzip",
+          ["-o", tmpZip, "-d", this.nodePtyDir],
           { timeout: 30000 }
         );
         // Ensure spawn-helper is executable

--- a/src/terminal-tab-manager.ts
+++ b/src/terminal-tab-manager.ts
@@ -456,7 +456,7 @@ export class TerminalTabManager {
         while ((match = re.exec(text)) !== null) {
           const name = match[1];
           const start = match.index + 1;
-          const end = match.index + match[0].length;
+          const end = match.index + match[0].length + 1;
           links.push({
             range: {
               start: { x: start, y: lineNumber },

--- a/src/terminal-tab-manager.ts
+++ b/src/terminal-tab-manager.ts
@@ -1,6 +1,6 @@
 import { Notice, App, FileSystemAdapter } from "obsidian";
 import type { AppWithDrag, ElectronWithWebUtils, FileWithPath } from "./obsidian-internals";
-import { Terminal } from "@xterm/xterm";
+import { Terminal, type ILink, type ILinkProvider } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { SerializeAddon } from "@xterm/addon-serialize";
@@ -414,15 +414,28 @@ export class TerminalTabManager {
         this.settings,
         this.themeRegistry,
       ),
+      linkHandler: {
+        activate: (_event: MouseEvent, uri: string) => {
+          if (!/^(https?|obsidian):\/\//i.test(uri)) return;
+          const { shell } = window.require("electron") as {
+            shell: { openExternal: (url: string) => Promise<void> };
+          };
+          void shell.openExternal(uri);
+        },
+        allowNonHttpProtocols: true,
+      },
     });
 
     const fitAddon = new FitAddon();
+    const WEB_LINK_REGEX =
+      /(https?|HTTPS?|obsidian):[/]{2}[^\s"'!*(){}|\\^<>`]*[^\s"':,.!?{}|\\^~[\]`()<>]/;
     const webLinksAddon = new WebLinksAddon((_event, uri) => {
+      if (!/^(https?|obsidian):\/\//i.test(uri)) return;
       const { shell } = window.require("electron") as {
         shell: { openExternal: (url: string) => Promise<void> };
       };
       void shell.openExternal(uri);
-    });
+    }, { urlRegex: WEB_LINK_REGEX });
     const serializeAddon = new SerializeAddon();
     const searchAddon = new SearchAddon();
 
@@ -431,6 +444,40 @@ export class TerminalTabManager {
     terminal.loadAddon(serializeAddon);
     terminal.loadAddon(searchAddon);
     terminal.open(containerEl);
+
+    terminal.registerLinkProvider({
+      provideLinks: (lineNumber: number, callback: (links: ILink[] | undefined) => void) => {
+        const line = terminal.buffer.active.getLine(lineNumber - 1);
+        if (!line) { callback([]); return; }
+        const text = line.translateToString(true);
+        const links: ILink[] = [];
+        const re = /\[\[([^\]|]+)(?:\|[^\]]+)?\]\]/g;
+        let match: RegExpExecArray | null;
+        while ((match = re.exec(text)) !== null) {
+          const name = match[1];
+          const start = match.index + 1;
+          const end = match.index + match[0].length;
+          links.push({
+            range: {
+              start: { x: start, y: lineNumber },
+              end: { x: end, y: lineNumber },
+            },
+            text: match[0],
+            decorations: { pointerCursor: true, underline: true },
+            activate: () => {
+              const vault = this.app.vault.getName();
+              const { shell } = window.require("electron") as {
+                shell: { openExternal: (url: string) => Promise<void> };
+              };
+              void shell.openExternal(
+                `obsidian://open?vault=${encodeURIComponent(vault)}&file=${encodeURIComponent(name)}`
+              );
+            },
+          });
+        }
+        callback(links);
+      },
+    });
 
     return { terminal, fitAddon, serializeAddon, searchAddon };
   }


### PR DESCRIPTION
## Summary

Implements issue #47 — adds three link-handling features to make Claude Code terminal output navigable within Obsidian:

1. **WikiLink click-to-open**: Click `[[NoteName]]` in terminal output to open that file in Obsidian
2. **obsidian:// URI support**: Extends WebLinksAddon to recognize and handle `obsidian://` URIs
3. **OSC 8 hyperlink support**: Enables escape-sequence hyperlinks with `obsidian://` schemes

## Implementation Details

- Adds `linkHandler` to Terminal options with `allowNonHttpProtocols: true`
- Extends WebLinksAddon regex to include `obsidian://` protocol
- Registers custom link provider for `[[WikiLink]]` pattern detection
- All URI schemes validated against allowlist (`https?|obsidian`) before `shell.openExternal`
- WikiLink names and vault names properly `encodeURIComponent` encoded
- Supports piped wiki links: `[[NoteName|Display Text]]`

## Security

- No `file://` protocol exposed (unnecessary and risky)
- Scheme validation in activate handlers prevents arbitrary protocol execution
- Plugin guidelines compliant: user-gesture required (click activation)
- Desktop-only plugin, Electron APIs properly used

## Testing

- Build: ✅ Compiles without errors
- Tests: ✅ All 70 tests pass
- Manual verification: Need to test in dev vault with actual terminal output

## Related

Fixes #47
Extends #41 (clickable URLs feature)

Co-Authored-By: Claude