### PR TITLE
docs: extract reference sections into standalone docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,51 +77,11 @@ An embedded terminal panel for [Obsidian](https://obsidian.md), powered by [xter
 
 ## Usage
 
-| Action | How |
-|--------|-----|
-| Open terminal | Click the terminal icon in the ribbon, or run **Open terminal** from the command palette |
-| Toggle terminal | Command palette: **Toggle terminal**, or click the ribbon icon again |
-| New tab | Command palette: **New terminal tab**, or click the **+** button in the tab bar |
-| Rename tab | Right-click the tab label |
-| Pin tab | Right-click the tab - **Pin** - hides the close button and blocks accidental close |
-| Reorder tabs | Drag a tab left or right when two or more tabs are open |
-| Drop file path | Drag a file from the file explorer or Windows Explorer into the terminal |
-| Search terminal output | Press **Ctrl+Alt+F** (configurable) to open the search bar |
-| Close tab | Click the **x** on the tab |
-| Open terminal in current file's folder | Command palette: **Open terminal in current file's directory** (only visible when a file is active) |
-| Open terminal in any folder | Right-click a file or folder in the file explorer - **Open terminal here** |
-| Split pane | Command palette: **Open terminal in new pane** |
-| Restore closed tab | Command palette: **Restore recent terminal session** - pick from recently closed tabs (and Claude sessions, if integration enabled) |
-| Refresh Claude session registry | Command palette: **Refresh Claude session registry** - rewrites the registry note (requires Claude integration enabled) |
+See [Usage](docs/usage.md) for the full command reference.
 
 ## Settings
 
-| Setting | Default | Description |
-|---------|---------|-------------|
-| Shell path | Auto-detect | Path to shell executable. Leave empty for auto-detection |
-| Startup command | none | Command to run automatically when a new terminal tab opens (e.g. `claude`, `npm run dev`) |
-| Font size | 14 | Terminal font size in pixels |
-| Font family | Menlo, Monaco, 'Courier New', monospace | Terminal font stack |
-| Theme | Obsidian Dark | Color theme for the terminal |
-| Icon | terminal | Lucide icon name for the ribbon and panel tab icon |
-| Cursor blink | On | Whether the cursor blinks |
-| Scrollback | 5000 | Number of lines kept in scroll history |
-| Background color | Theme default | Override the theme background with any CSS color (hex, RGB, etc.) |
-| Default location | Bottom | Where new terminal panels open (Bottom or Right) |
-| Notify on completion | Off | Sound + notice when a background tab command finishes |
-| Notification sound | Beep | Choose from Beep, Chime, Ping, or Pop |
-| Notification volume | 50 | Volume for notification sounds (0–100) |
-| Persist terminal buffer | On | Save scrollback history across restarts. Disable to reduce workspace.json size |
-| Recent sessions to keep | 10 | Closed-tab rescue buffer size. Set to 0 to disable |
-| Enable Claude Code integration | Off | Scan `~/.claude/` for sessions, register the `obsidian://lean-terminal` URI handler, include Claude sessions in the restore picker |
-| Registry note path | claude-sessions.md | Vault-relative path to the auto-maintained Claude sessions registry |
-| Registry sessions to keep | 25 | Max Claude sessions listed in the registry note and picker |
-| Copy on select | Off | Automatically copy selected text to the clipboard |
-| Search shortcut | Ctrl+Alt+F | Keyboard shortcut to open the in-terminal search bar |
-| Wiki-link autocomplete | Off | Type `[[` in the terminal to open a searchable vault note picker |
-| Wiki-link insertion format | Wiki-link | How an accepted note is inserted: `[[Note]]`, vault-relative path, or absolute path |
-| Line height | 1.0 | Terminal line height multiplier (1.0-2.0). Changes apply instantly to open tabs |
-| Tab bar position | Top | Position of the tab bar: Top (horizontal, default), Left, or Right (vertical stacking) |
+See [Settings](docs/settings.md) for all configuration options.
 
 ## How It Works
 
@@ -131,69 +91,19 @@ On Windows, the plugin uses the ConPTY backend (correct UTF-8 and emoji support)
 
 ## Session Persistence
 
-Each terminal tab's name, color, working directory, and scrollback buffer are saved to the workspace layout on close and on Obsidian quit. On next launch, tabs are restored with their history visible and a fresh shell spawned in the saved directory. This is visual/history restore - the underlying shell process does not survive quit.
-
-Closing a tab (**x** button) pushes its state to a rescue ring buffer stored in plugin data. Use **Restore recent terminal session** from the command palette to re-open a closed tab at any point.
+See [Session Persistence](docs/session-persistence.md) for how tab state is saved and restored.
 
 ## Claude Code Integration
 
-Disabled by default. When enabled in settings, the plugin:
-
-- Scans `~/.claude/projects/` for conversation sessions associated with the current vault
-- Generates a markdown registry note on demand (**Refresh Claude session registry** command) with clickable Resume links
-- Registers the `obsidian://lean-terminal?resume=<session-id>` URI so links in the registry (or any note) open a new terminal tab and run `claude --resume <session-id>` once the shell is ready
-- Includes Claude sessions alongside recently closed tabs in the **Restore recent terminal session** picker, sorted by most recent
-
-Sessions started by typing `claude` manually inside a tab are not auto-tracked, but appear in the picker on its next open (the scan runs fresh each time) - click to resume.
+See [Claude Code Integration](docs/claude-code-integration.md) for setup and usage.
 
 ## URI Handler
 
-The plugin registers the `obsidian://lean-terminal` protocol handler, usable from any note link, dashboard button, or external script:
-
-| Parameter | Description | Example |
-|-----------|-------------|---------|
-| `cwd` | Open a terminal tab in the given directory (URL-encoded path) | `obsidian://lean-terminal?cwd=%2Fhome%2Fuser%2Fprojects%2Fmy-app` |
-| `resume` | Open a terminal tab and run `claude --resume <session-id>` once the shell is ready (requires Claude integration enabled) | `obsidian://lean-terminal?resume=<uuid>` |
-
-The `cwd` parameter is useful for dashboards and launchers. In an Obsidian note with Dataview JS or a custom button plugin:
-
-```js
-app.workspace.openLinkText("obsidian://lean-terminal?cwd=" + encodeURIComponent("/path/to/project"), "");
-```
-
-Or as a plain Markdown link (paths must be URL-encoded):
-
-```markdown
-[Open project terminal](obsidian://lean-terminal?cwd=%2Fpath%2Fto%2Fproject)
-```
-
-If the terminal panel is already open, the URI opens a new tab in the target directory. If it is closed, a fresh panel opens there.
+See [URI Handler](docs/uri-handler.md) for the `obsidian://lean-terminal` protocol reference.
 
 ## Security
 
-A full security review of the codebase was conducted covering code-level vulnerabilities, native module handling, and supply chain risks. Here is what was checked and what was found.
-
-**Checks performed:**
-- Command/shell injection in PTY spawn, shell path handling, and ZIP extraction
-- Path traversal in file operations
-- Input validation at all user-facing and URI-handler boundaries
-- Integrity verification of downloaded native binaries
-- XSS and prototype pollution in the Obsidian UI layer
-- Hardcoded secrets, sensitive data in logs, and dynamic code execution
-- GitHub Actions workflow supply chain (trigger conditions, action pinning)
-- npm dependency audit for known CVEs
-
-**No issues found in:**
-- Shell command construction (all paths fed into `execSync` are system-controlled, not user-supplied)
-- Claude session resume commands (UUID-validated before PTY write)
-- Obsidian UI rendering (no `innerHTML` or `eval` usage)
-- Hardcoded credentials or tokens
-
-**Binary download integrity:**
-
-When the plugin downloads native `node-pty` binaries from GitHub Releases, it verifies their SHA-256 checksum against a `checksums.json` file published alongside the release. Checksum verification is mandatory - if `checksums.json` is unreachable or does not contain an entry for the downloaded asset, the installation is aborted.
-
-SHA-256 checksums for each release are also published in `checksums.json` attached to every [GitHub Release](https://github.com/sdkasper/lean-obsidian-terminal/releases) for manual verification.
+See [Security](docs/security.md) for the security review summary.
 
 ## Feedback
 

--- a/docs/claude-code-integration.md
+++ b/docs/claude-code-integration.md
@@ -1,0 +1,10 @@
+# Claude Code Integration
+
+Disabled by default. When enabled in settings, the plugin:
+
+- Scans `~/.claude/projects/` for conversation sessions associated with the current vault
+- Generates a markdown registry note on demand (**Refresh Claude session registry** command) with clickable Resume links
+- Registers the `obsidian://lean-terminal?resume=<session-id>` URI so links in the registry (or any note) open a new terminal tab and run `claude --resume <session-id>` once the shell is ready
+- Includes Claude sessions alongside recently closed tabs in the **Restore recent terminal session** picker, sorted by most recent
+
+Sessions started by typing `claude` manually inside a tab are not auto-tracked, but appear in the picker on its next open (the scan runs fresh each time) - click to resume.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,25 @@
+# Security
+
+A full security review of the codebase was conducted covering code-level vulnerabilities, native module handling, and supply chain risks. Here is what was checked and what was found.
+
+**Checks performed:**
+- Command/shell injection in PTY spawn, shell path handling, and ZIP extraction
+- Path traversal in file operations
+- Input validation at all user-facing and URI-handler boundaries
+- Integrity verification of downloaded native binaries
+- XSS and prototype pollution in the Obsidian UI layer
+- Hardcoded secrets, sensitive data in logs, and dynamic code execution
+- GitHub Actions workflow supply chain (trigger conditions, action pinning)
+- npm dependency audit for known CVEs
+
+**No issues found in:**
+- Shell command construction (all paths fed into `execSync` are system-controlled, not user-supplied)
+- Claude session resume commands (UUID-validated before PTY write)
+- Obsidian UI rendering (no `innerHTML` or `eval` usage)
+- Hardcoded credentials or tokens
+
+**Binary download integrity:**
+
+When the plugin downloads native `node-pty` binaries from GitHub Releases, it verifies their SHA-256 checksum against a `checksums.json` file published alongside the release. Checksum verification is mandatory - if `checksums.json` is unreachable or does not contain an entry for the downloaded asset, the installation is aborted.
+
+SHA-256 checksums for each release are also published in `checksums.json` attached to every [GitHub Release](https://github.com/sdkasper/lean-obsidian-terminal/releases) for manual verification.

--- a/docs/session-persistence.md
+++ b/docs/session-persistence.md
@@ -1,0 +1,5 @@
+# Session Persistence
+
+Each terminal tab's name, color, working directory, and scrollback buffer are saved to the workspace layout on close and on Obsidian quit. On next launch, tabs are restored with their history visible and a fresh shell spawned in the saved directory. This is visual/history restore - the underlying shell process does not survive quit.
+
+Closing a tab (**x** button) pushes its state to a rescue ring buffer stored in plugin data. Use **Restore recent terminal session** from the command palette to re-open a closed tab at any point.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1,0 +1,28 @@
+# Settings
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| Shell path | Auto-detect | Path to shell executable. Leave empty for auto-detection |
+| Startup command | none | Command to run automatically when a new terminal tab opens (e.g. `claude`, `npm run dev`) |
+| Font size | 14 | Terminal font size in pixels |
+| Font family | Menlo, Monaco, 'Courier New', monospace | Terminal font stack |
+| Theme | Obsidian Dark | Color theme for the terminal |
+| Icon | terminal | Lucide icon name for the ribbon and panel tab icon |
+| Cursor blink | On | Whether the cursor blinks |
+| Scrollback | 5000 | Number of lines kept in scroll history |
+| Background color | Theme default | Override the theme background with any CSS color (hex, RGB, etc.) |
+| Default location | Bottom | Where new terminal panels open (Bottom or Right) |
+| Notify on completion | Off | Sound + notice when a background tab command finishes |
+| Notification sound | Beep | Choose from Beep, Chime, Ping, or Pop |
+| Notification volume | 50 | Volume for notification sounds (0–100) |
+| Persist terminal buffer | On | Save scrollback history across restarts. Disable to reduce workspace.json size |
+| Recent sessions to keep | 10 | Closed-tab rescue buffer size. Set to 0 to disable |
+| Enable Claude Code integration | Off | Scan `~/.claude/` for sessions, register the `obsidian://lean-terminal` URI handler, include Claude sessions in the restore picker |
+| Registry note path | claude-sessions.md | Vault-relative path to the auto-maintained Claude sessions registry |
+| Registry sessions to keep | 25 | Max Claude sessions listed in the registry note and picker |
+| Copy on select | Off | Automatically copy selected text to the clipboard |
+| Search shortcut | Ctrl+Alt+F | Keyboard shortcut to open the in-terminal search bar |
+| Wiki-link autocomplete | Off | Type `[[` in the terminal to open a searchable vault note picker |
+| Wiki-link insertion format | Wiki-link | How an accepted note is inserted: `[[Note]]`, vault-relative path, or absolute path |
+| Line height | 1.0 | Terminal line height multiplier (1.0-2.0). Changes apply instantly to open tabs |
+| Tab bar position | Top | Position of the tab bar: Top (horizontal, default), Left, or Right (vertical stacking) |

--- a/docs/uri-handler.md
+++ b/docs/uri-handler.md
@@ -1,0 +1,22 @@
+# URI Handler
+
+The plugin registers the `obsidian://lean-terminal` protocol handler, usable from any note link, dashboard button, or external script:
+
+| Parameter | Description | Example |
+|-----------|-------------|---------|
+| `cwd` | Open a terminal tab in the given directory (URL-encoded path) | `obsidian://lean-terminal?cwd=%2Fhome%2Fuser%2Fprojects%2Fmy-app` |
+| `resume` | Open a terminal tab and run `claude --resume <session-id>` once the shell is ready (requires Claude integration enabled) | `obsidian://lean-terminal?resume=<uuid>` |
+
+The `cwd` parameter is useful for dashboards and launchers. In an Obsidian note with Dataview JS or a custom button plugin:
+
+```js
+app.workspace.openLinkText("obsidian://lean-terminal?cwd=" + encodeURIComponent("/path/to/project"), "");
+```
+
+Or as a plain Markdown link (paths must be URL-encoded):
+
+```markdown
+[Open project terminal](obsidian://lean-terminal?cwd=%2Fpath%2Fto%2Fproject)
+```
+
+If the terminal panel is already open, the URI opens a new tab in the target directory. If it is closed, a fresh panel opens there.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,18 @@
+# Usage
+
+| Action | How |
+|--------|-----|
+| Open terminal | Click the terminal icon in the ribbon, or run **Open terminal** from the command palette |
+| Toggle terminal | Command palette: **Toggle terminal**, or click the ribbon icon again |
+| New tab | Command palette: **New terminal tab**, or click the **+** button in the tab bar |
+| Rename tab | Right-click the tab label |
+| Pin tab | Right-click the tab - **Pin** - hides the close button and blocks accidental close |
+| Reorder tabs | Drag a tab left or right when two or more tabs are open |
+| Drop file path | Drag a file from the file explorer or Windows Explorer into the terminal |
+| Search terminal output | Press **Ctrl+Alt+F** (configurable) to open the search bar |
+| Close tab | Click the **x** on the tab |
+| Open terminal in current file's folder | Command palette: **Open terminal in current file's directory** (only visible when a file is active) |
+| Open terminal in any folder | Right-click a file or folder in the file explorer - **Open terminal here** |
+| Split pane | Command palette: **Open terminal in new pane** |
+| Restore closed tab | Command palette: **Restore recent terminal session** - pick from recently closed tabs (and Claude sessions, if integration enabled) |
+| Refresh Claude session registry | Command palette: **Refresh Claude session registry** - rewrites the registry note (requires Claude integration enabled) |


### PR DESCRIPTION
## Summary

Refactored the README to improve clarity and readability by extracting reference sections into standalone docs files.

**Sections moved:**
- Usage → docs/usage.md
- Settings → docs/settings.md
- Session Persistence → docs/session-persistence.md
- Claude Code Integration → docs/claude-code-integration.md
- URI Handler → docs/uri-handler.md
- Security → docs/security.md

**README now focuses on:**
- Features
- Installation
- How It Works
- Feedback, Development, Contributors, License

README size: 231 → 140 lines. All reference material remains accessible via links.

Co-Authored-By: Claude <noreply@anthropic.com>