### PR TITLE
chore: add changelog automation

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,44 @@
+name: Update Changelog
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout master
+        uses: actions/checkout@v4
+        with:
+          ref: master
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Generate CHANGELOG.md
+        run: node scripts/generate-changelog.mjs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: update CHANGELOG for ${{ github.ref_name }}"
+          branch: changelog/${{ github.ref_name }}
+          title: "chore: update CHANGELOG for ${{ github.ref_name }}"
+          body: |
+            Automated changelog update for release **${{ github.ref_name }}**.
+
+            This PR was generated automatically when the release was published.
+            Review and merge to update CHANGELOG.md on master.
+          labels: |
+            changelog
+          assignees: sdkasper

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,127 @@
+# Changelog
+
+All notable changes to Lean Obsidian Terminal are documented here.
+
+## 0.16.0 - May 11, 2026
+
+### New
+
+- feat: Clickable [[wikilinks]] and obsidian:// URI support
+
+### Improvements
+
+- docs: add line height setting to README
+
+## 0.15.0 - May 7, 2026
+
+### New
+
+- feat: URI protocol handler for directory-specific terminal launch (v0.14.0)
+- Add donation link to README
+- feat: clickable URLs + lineHeight live updates (fixes #41, #42)
+
+### Improvements
+
+- docs: reorganize features section into logical groups
+- ci: auto-add new issues to LOT Feedback Tracker project
+
+## 0.14.0 - May 4, 2026
+
+### Improvements
+
+- docs: add shields.io badges to README
+- docs: restyle badges to LeanProductivity brand colors
+- docs: per-badge brand colors for issues open/closed
+- docs: fix badge color scheme
+- revert: badge color scheme changes from PR #31
+- docs: finalize badge colors to LP brand spec
+- docs: set value bg to black for stars, manifest, downloads
+- docs: add Obsidian and License badges
+- docs: consolidate issues badges
+- docs: refresh badge lineup
+
+## 0.12.4 - April 29, 2026
+
+### New
+
+- feat: keyboard shortcuts for terminal tab navigation (v0.12.4)
+
+## 0.12.3 - April 29, 2026
+
+### Improvements
+
+- Release v0.12.3 - Vitest test framework, code quality fixes, plugin requirements compliance
+
+## 0.12.2 - April 28, 2026
+
+## 0.12.0 - April 28, 2026
+
+## 0.11.0 - April 28, 2026
+
+## 0.9.6 - April 24, 2026
+
+## 0.9.5 - April 24, 2026
+
+## 0.9.4 - April 23, 2026
+
+## 0.9.2 - April 23, 2026
+
+## 0.9.1 - April 22, 2026
+
+## 0.9.0 - April 21, 2026
+
+### New
+
+- Add 8 built-in color schemes + user-editable themes.json
+
+### Improvements
+
+- @FarhadGSRX made their first contribution in https://github.com/sdkasper/lean-obsidian-terminal/pull/12
+
+## 0.8.0 - April 21, 2026
+
+### Improvements
+
+- @kkugot made their first contribution in https://github.com/sdkasper/lean-obsidian-terminal/pull/5
+
+### Bug fixes
+
+- Fix emoji rendering and add system theme with terminal color reporting
+
+## 0.7.0 - April 20, 2026
+
+## 0.6.5 - April 15, 2026
+
+### Improvements
+
+- @CHodder5 made their first contribution in https://github.com/sdkasper/lean-obsidian-terminal/pull/10
+
+### Bug fixes
+
+- fix(zsh): forward .zshenv and .zprofile through ZDOTDIR override
+
+## 0.6.4 - April 15, 2026
+
+## 0.6.3 - April 2, 2026
+
+## 0.6.2 - April 2, 2026
+
+## 0.6.1 - April 1, 2026
+
+## 0.6.0 - April 1, 2026
+
+## 0.5.0 - March 31, 2026
+
+## 0.4.1 - March 26, 2026
+
+## 0.4.0 - March 26, 2026
+
+## v0.3.0 - March 26, 2026
+
+## v0.2.0 - March 25, 2026
+
+## v0.1.1 - March 25, 2026
+
+## v0.1.0 - March 25, 2026
+
+Older releases and more details: [GitHub Releases](https://github.com/sdkasper/lean-obsidian-terminal/releases)

--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ See [URI Handler](docs/uri-handler.md) for the `obsidian://lean-terminal` protoc
 
 See [Security](docs/security.md) for the security review summary.
 
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for release history and feature documentation by version.
+
 ## Feedback
 
 Use this repo to report bugs, request features, or ask questions.

--- a/scripts/generate-changelog.mjs
+++ b/scripts/generate-changelog.mjs
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+
+import fs from 'fs';
+
+const REPO = 'sdkasper/lean-obsidian-terminal';
+const API_URL = `https://api.github.com/repos/${REPO}/releases`;
+const TOKEN = process.env.GITHUB_TOKEN;
+
+/**
+ * Fetch all releases from GitHub API.
+ * Uses per_page=100 to get all releases in one request.
+ */
+async function fetchReleases() {
+  const url = new URL(API_URL);
+  url.searchParams.set('per_page', '100');
+
+  const options = {
+    headers: {
+      'Accept': 'application/vnd.github.v3+json',
+      'User-Agent': 'lean-obsidian-terminal-changelog-generator',
+    },
+  };
+
+  if (TOKEN) {
+    options.headers['Authorization'] = `token ${TOKEN}`;
+  }
+
+  const res = await fetch(url.toString(), options);
+  if (!res.ok) {
+    throw new Error(`GitHub API error: ${res.status} ${res.statusText}`);
+  }
+  return res.json();
+}
+
+/**
+ * Parse a release body and categorize entries.
+ * Infers categories from keywords:
+ * - "fix:", "bug:", "fixed" -> Bug fixes
+ * - "add:", "new:", "feat:", "feature:" -> New
+ * - Everything else -> Improvements
+ */
+function parseReleaseBody(body) {
+  if (!body || body.trim() === '') {
+    return { new: [], improvements: [], bugfixes: [] };
+  }
+
+  const lines = body.split('\n');
+  const entries = { new: [], improvements: [], bugfixes: [] };
+
+  for (const line of lines) {
+    // Skip section headers and full changelog link
+    if (line.startsWith('## ') || line.startsWith('**Full Changelog')) {
+      continue;
+    }
+
+    // Extract bullet point text
+    let text = line.trim();
+    if (!text.startsWith('*') && !text.startsWith('-')) {
+      continue;
+    }
+
+    // Remove bullet marker
+    text = text.replace(/^[\*\-]\s+/, '').trim();
+
+    // Strip attribution: " by @username in #123" or " by @username in https://..."
+    text = text.replace(/\s+by\s+@[\w\-]+.*$/i, '').trim();
+
+    if (!text) {
+      continue;
+    }
+
+    // Categorize by keyword
+    const lowerText = text.toLowerCase();
+    if (lowerText.startsWith('fix') || lowerText.startsWith('bug') || lowerText.includes('fixed')) {
+      entries.bugfixes.push(text);
+    } else if (
+      lowerText.startsWith('add') ||
+      lowerText.startsWith('new') ||
+      lowerText.startsWith('feat') ||
+      lowerText.startsWith('feature')
+    ) {
+      entries.new.push(text);
+    } else {
+      entries.improvements.push(text);
+    }
+  }
+
+  return entries;
+}
+
+/**
+ * Format a date as "Month DD, YYYY"
+ */
+function formatDate(isoString) {
+  const date = new Date(isoString);
+  const options = { year: 'numeric', month: 'long', day: 'numeric' };
+  return date.toLocaleDateString('en-US', options);
+}
+
+/**
+ * Build the changelog markdown content.
+ */
+function buildChangelog(releases) {
+  let content = '# Changelog\n\n';
+  content += 'All notable changes to Lean Obsidian Terminal are documented here.\n\n';
+
+  for (const release of releases) {
+    const version = release.tag_name;
+    const date = formatDate(release.published_at);
+    const parsed = parseReleaseBody(release.body);
+
+    content += `## ${version} - ${date}\n\n`;
+
+    // New section
+    if (parsed.new.length > 0) {
+      content += '### New\n\n';
+      for (const entry of parsed.new) {
+        content += `- ${entry}\n`;
+      }
+      content += '\n';
+    }
+
+    // Improvements section
+    if (parsed.improvements.length > 0) {
+      content += '### Improvements\n\n';
+      for (const entry of parsed.improvements) {
+        content += `- ${entry}\n`;
+      }
+      content += '\n';
+    }
+
+    // Bug fixes section
+    if (parsed.bugfixes.length > 0) {
+      content += '### Bug fixes\n\n';
+      for (const entry of parsed.bugfixes) {
+        content += `- ${entry}\n`;
+      }
+      content += '\n';
+    }
+  }
+
+  // Footer
+  content += `Older releases and more details: [GitHub Releases](https://github.com/${REPO}/releases)\n`;
+
+  return content;
+}
+
+/**
+ * Main entry point.
+ */
+async function main() {
+  try {
+    console.log('Fetching releases from GitHub API...');
+    const releases = await fetchReleases();
+
+    if (!Array.isArray(releases) || releases.length === 0) {
+      console.error('Error: No releases found');
+      process.exit(1);
+    }
+
+    console.log(`Found ${releases.length} releases`);
+
+    const changelog = buildChangelog(releases);
+    fs.writeFileSync('CHANGELOG.md', changelog, 'utf8');
+
+    console.log('✓ CHANGELOG.md written successfully');
+    process.exit(0);
+  } catch (error) {
+    console.error('Error:', error.message);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
Add CHANGELOG.md auto-generation via GitHub Actions workflow.

- New script: scripts/generate-changelog.mjs (fetches GitHub Releases API, categorizes entries)
- New workflow: .github/workflows/changelog.yml (auto-updates CHANGELOG.md on release)
- Bootstrapped CHANGELOG.md with all 29 releases (0.1.0-0.16.0)
- Updated README.md with CHANGELOG link

All tasks reviewed and approved. Production-ready.