### PR TITLE
feat: attach images on paste and drop

### DIFF
--- a/src/obsidian-internals.ts
+++ b/src/obsidian-internals.ts
@@ -15,6 +15,17 @@ export interface ElectronWithWebUtils {
   webUtils: { getPathForFile(file: File): string };
 }
 
+/** Minimal Electron NativeImage surface used for clipboard image paste. */
+export interface ElectronNativeImage {
+  isEmpty(): boolean;
+  toPNG(): Buffer;
+}
+
+/** Electron clipboard accessor for reading images pasted from the OS. */
+export interface ElectronWithClipboard {
+  clipboard: { readImage(): ElectronNativeImage };
+}
+
 /** Legacy Electron File extension — .path was available before Electron 32. */
 export interface FileWithPath extends File {
   path?: string;

--- a/src/terminal-tab-manager.ts
+++ b/src/terminal-tab-manager.ts
@@ -1,5 +1,5 @@
 import { Notice, App, FileSystemAdapter } from "obsidian";
-import type { AppWithDrag, ElectronWithWebUtils, FileWithPath } from "./obsidian-internals";
+import type { AppWithDrag, ElectronWithWebUtils, ElectronWithClipboard, FileWithPath } from "./obsidian-internals";
 import { Terminal, type ILink } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
@@ -220,6 +220,45 @@ function quotePath(rawPath: string, shellPath: string): string {
     return `'${rawPath}'`;
   }
   return `"${rawPath}"`;
+}
+
+/** Raster image extensions that TUIs such as Claude Code attach as vision input. */
+const IMAGE_PATH_PATTERN = /\.(png|jpe?g|gif|webp|bmp)$/i;
+
+function isImagePath(path: string): boolean {
+  return IMAGE_PATH_PATTERN.test(path);
+}
+
+/**
+ * Wrap text in bracketed-paste markers (ESC[200~ … ESC[201~). A raw `pty.write`
+ * arrives as individually typed characters; CLI apps like Claude Code only treat
+ * an incoming file path as a pasted image attachment when it is delivered as a
+ * single bracketed paste, matching what a real terminal paste sends.
+ */
+function bracketedPaste(text: string): string {
+  return `\x1b[200~${text}\x1b[201~`;
+}
+
+/**
+ * If the OS clipboard holds an image, persist it to a temp PNG and write the
+ * path to the PTY as a bracketed paste so the running app attaches it.
+ * Returns true when an image was handled, false to fall through to text paste.
+ */
+function pasteClipboardImage(pty: PtyManager): boolean {
+  try {
+    const { clipboard } = window.require("electron") as ElectronWithClipboard;
+    const image = clipboard.readImage();
+    if (!image || image.isEmpty()) return false;
+    const os = window.require("os") as { tmpdir(): string };
+    const fs = window.require("fs") as { writeFileSync(p: string, d: Buffer): void };
+    const path = window.require("path") as { join(...p: string[]): string };
+    const file = path.join(os.tmpdir(), `lean-terminal-paste-${Date.now()}.png`);
+    fs.writeFileSync(file, image.toPNG());
+    pty.write(bracketedPaste(file));
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function extractDropPath(e: DragEvent, app: App): string | null {
@@ -524,7 +563,12 @@ export class TerminalTabManager {
       hideLabel();
       const path = extractDropPath(e, this.app);
       if (!path) return;
-      pty.write(quotePath(path, pty.shellPath));
+      // Dropped images attach as files; other files insert as a quoted path.
+      if (isImagePath(path)) {
+        pty.write(bracketedPaste(path));
+      } else {
+        pty.write(quotePath(path, pty.shellPath));
+      }
     });
 
     return dragLabel;
@@ -639,11 +683,11 @@ export class TerminalTabManager {
       // Paste: Ctrl+V / Cmd+V / Shift+Insert
       if ((mod && e.key === "v") || (e.shiftKey && e.key === "Insert")) {
         e.preventDefault();
+        const s = this.sessions.find((s) => s.id === id);
+        // An image on the clipboard is attached as a file; otherwise paste text.
+        if (s && pasteClipboardImage(s.pty)) return false;
         navigator.clipboard.readText().then((text) => {
-          if (text) {
-            const s = this.sessions.find((s) => s.id === id);
-            if (s) s.pty.write(text);
-          }
+          if (text && s) s.pty.write(text);
         }).catch(() => { /* clipboard unavailable */ });
         return false;
       }

--- a/src/terminal-tab-manager.ts
+++ b/src/terminal-tab-manager.ts
@@ -239,10 +239,16 @@ function bracketedPaste(text: string): string {
   return `\x1b[200~${text}\x1b[201~`;
 }
 
+/** Monotonic counter so rapid pastes in the same millisecond get unique names. */
+let pasteImageCounter = 0;
+
 /**
  * If the OS clipboard holds an image, persist it to a temp PNG and write the
  * path to the PTY as a bracketed paste so the running app attaches it.
  * Returns true when an image was handled, false to fall through to text paste.
+ *
+ * The temp file is deleted after a short delay: the receiving app reads the
+ * image as soon as the path is pasted, so it is no longer needed afterwards.
  */
 function pasteClipboardImage(pty: PtyManager): boolean {
   try {
@@ -250,13 +256,21 @@ function pasteClipboardImage(pty: PtyManager): boolean {
     const image = clipboard.readImage();
     if (!image || image.isEmpty()) return false;
     const os = window.require("os") as { tmpdir(): string };
-    const fs = window.require("fs") as { writeFileSync(p: string, d: Buffer): void };
+    const fs = window.require("fs") as {
+      writeFileSync(p: string, d: Buffer): void;
+      unlinkSync(p: string): void;
+    };
     const path = window.require("path") as { join(...p: string[]): string };
-    const file = path.join(os.tmpdir(), `lean-terminal-paste-${Date.now()}.png`);
+    const name = `lean-terminal-paste-${Date.now()}-${pasteImageCounter++}.png`;
+    const file = path.join(os.tmpdir(), name);
     fs.writeFileSync(file, image.toPNG());
     pty.write(bracketedPaste(file));
+    window.setTimeout(() => {
+      try { fs.unlinkSync(file); } catch { /* already gone */ }
+    }, 10000);
     return true;
-  } catch {
+  } catch (err) {
+    console.warn("[lean-terminal] Image paste failed:", err);
     return false;
   }
 }


### PR DESCRIPTION
Adds native image attachment to the terminal, matching what standalone terminals (iTerm, Warp) do with CLI tools such as Claude Code.

## What

- **Paste:** if the OS clipboard holds an image, it is written to a temp PNG and the path is sent to the PTY as a bracketed paste, so the running app attaches it as an image instead of pasting nothing.
- **Drop:** dropping an image file attaches it the same way; non-image files keep the existing quoted-path behaviour.

## Why bracketed paste

A raw `pty.write` of a path arrives as individually typed characters, which apps do not treat as a pasted file. Wrapping the path in bracketed-paste markers (`ESC[200~ ... ESC[201~`) matches what a real terminal paste sends, so the app attaches it.

## Implementation

- `pasteClipboardImage()` and `bracketedPaste()`/`isImagePath()` helpers in `terminal-tab-manager.ts`, alongside the existing `quotePath`/`extractDropPath`.
- Minimal `ElectronWithClipboard`/`ElectronNativeImage` types in `obsidian-internals.ts`, following the existing `ElectronWithWebUtils` pattern.
- Image-clipboard read uses Electron's `clipboard.readImage()`; everything is wrapped in try/catch and falls back to the current text-paste / quoted-path behaviour.

## Testing

Tested on macOS with Claude Code: both paste and Finder drop (including filenames with spaces) produce a native `[Image]` attachment.

The plugin-side APIs are cross-platform, but **Windows path-attachment behaviour is unverified** and would benefit from a tester (backslash paths may need normalising).

Happy to retarget this to `beta`/`work` if that fits the branching flow better, and to add a toggle or a note in `docs/claude-code-integration.md` if you'd like.
