### PR TITLE
feat: make file paths clickable

### DIFF
--- a/src/terminal-tab-manager.ts
+++ b/src/terminal-tab-manager.ts
@@ -559,14 +559,10 @@ export class TerminalTabManager {
             },
             text: match[0],
             decorations: { pointerCursor: true, underline: true },
-            activate: () => {
-              const vault = this.app.vault.getName();
-              const { shell } = window.require("electron") as {
-                shell: { openExternal: (url: string) => Promise<void> };
-              };
-              void shell.openExternal(
-                `obsidian://open?vault=${encodeURIComponent(vault)}&file=${encodeURIComponent(name)}`
-              );
+            activate: (event: MouseEvent) => {
+              // Cmd/Ctrl+click opens in a new tab, like Obsidian's own links.
+              const newLeaf = event.metaKey || event.ctrlKey ? "tab" : false;
+              void this.app.workspace.openLinkText(name, "", newLeaf);
             },
           });
         }

--- a/src/terminal-tab-manager.ts
+++ b/src/terminal-tab-manager.ts
@@ -561,8 +561,12 @@ export class TerminalTabManager {
             decorations: { pointerCursor: true, underline: true },
             activate: (event: MouseEvent) => {
               // Cmd/Ctrl+click opens in a new tab, like Obsidian's own links.
-              const newLeaf = event.metaKey || event.ctrlKey ? "tab" : false;
-              void this.app.workspace.openLinkText(name, "", newLeaf);
+              const dest = this.app.metadataCache.getFirstLinkpathDest(name, "");
+              if ((event.metaKey || event.ctrlKey) && dest) {
+                void this.app.workspace.getLeaf("tab").openFile(dest);
+              } else {
+                void this.app.workspace.openLinkText(name, "", false);
+              }
             },
           });
         }
@@ -590,8 +594,12 @@ export class TerminalTabManager {
             activate: (event: MouseEvent) => {
               if (target.kind === "vault") {
                 // Cmd/Ctrl+click opens in a new tab, like Obsidian's own links.
-                const newLeaf = event.metaKey || event.ctrlKey ? "tab" : false;
-                void this.app.workspace.openLinkText(target.linkpath, "", newLeaf);
+                const dest = this.app.vault.getAbstractFileByPath(target.linkpath);
+                if ((event.metaKey || event.ctrlKey) && dest instanceof TFile) {
+                  void this.app.workspace.getLeaf("tab").openFile(dest);
+                } else {
+                  void this.app.workspace.openLinkText(target.linkpath, "", false);
+                }
               } else {
                 const { shell } = window.require("electron") as {
                   shell: { openPath: (p: string) => Promise<string> };

--- a/src/terminal-tab-manager.ts
+++ b/src/terminal-tab-manager.ts
@@ -262,14 +262,15 @@ const PATH_TRAILING_PUNCTUATION = /[.,;:!?)\]}>'"]+$/;
 
 /**
  * Find path-like tokens on a line: single/double-quoted strings, or unquoted
- * runs containing a slash. Each result carries the 0-based column span of the
- * path itself (surrounding quotes excluded) so a link range can be built.
+ * runs containing a slash (forward or back, for Windows paths). Each result
+ * carries the 0-based column span of the path itself (surrounding quotes
+ * excluded) so a link range can be built.
  */
 function findPathCandidates(text: string): { value: string; start: number; end: number }[] {
   const results: { value: string; start: number; end: number }[] = [];
   // 1: 'quoted'  2: "quoted"  3: unquoted path with a slash  4: bare filename.ext
   const re =
-    /'([^']+)'|"([^"]+)"|([^\s"'`()<>]*\/[^\s"'`()<>]+)|([^\s"'`()<>/]+\.[A-Za-z0-9]{1,8})/g;
+    /'([^']+)'|"([^"]+)"|([^\s"'`()<>]*[\\/][^\s"'`()<>]+)|([^\s"'`()<>\\/]+\.[A-Za-z0-9]+)/g;
   let match: RegExpExecArray | null;
   while ((match = re.exec(text)) !== null) {
     const quoted = match[1] ?? match[2];
@@ -290,14 +291,23 @@ type PathTarget =
   | { kind: "vault"; linkpath: string }
   | { kind: "external"; absPath: string };
 
-/** True if the absolute path exists and is a regular file. */
+/** Cache stat results so hovering/redrawing lines does not re-hit the disk. */
+const fileExistsCache = new Map<string, boolean>();
+
+/** True if the absolute path exists and is a regular file (cached). */
 function isExistingFile(absPath: string): boolean {
+  const cached = fileExistsCache.get(absPath);
+  if (cached !== undefined) return cached;
+  let result = false;
   try {
     const fs = window.require("fs") as { statSync(p: string): { isFile(): boolean } };
-    return fs.statSync(absPath).isFile();
+    result = fs.statSync(absPath).isFile();
   } catch {
-    return false;
+    result = false;
   }
+  if (fileExistsCache.size > 1000) fileExistsCache.clear();
+  fileExistsCache.set(absPath, result);
+  return result;
 }
 
 /**
@@ -306,21 +316,22 @@ function isExistingFile(absPath: string): boolean {
  * absolute paths outside the vault open in the system default application.
  */
 function resolvePathTarget(candidate: string, app: App): PathTarget | null {
+  // Normalise backslashes so Windows paths resolve like POSIX ones.
+  const norm = candidate.split("\\").join("/");
   let abs: string | null = null;
-  if (candidate.startsWith("/")) {
-    abs = candidate;
-  } else if (candidate.startsWith("~/")) {
+  if (norm.startsWith("/") || /^[A-Za-z]:\//.test(norm)) {
+    abs = norm; // POSIX or Windows drive-absolute (e.g. C:/Users/...)
+  } else if (norm.startsWith("~/")) {
     const os = window.require("os") as { homedir(): string };
-    abs = os.homedir() + candidate.slice(1);
+    abs = os.homedir().split("\\").join("/") + norm.slice(1);
   }
 
   if (abs !== null) {
     const adapter = app.vault.adapter;
     if (adapter instanceof FileSystemAdapter) {
       const base = adapter.getBasePath().split("\\").join("/");
-      const absFwd = abs.split("\\").join("/");
-      if (absFwd.startsWith(base + "/")) {
-        const rel = absFwd.slice(base.length + 1);
+      if (abs.startsWith(base + "/")) {
+        const rel = abs.slice(base.length + 1);
         return app.vault.getAbstractFileByPath(rel) instanceof TFile
           ? { kind: "vault", linkpath: rel }
           : null;
@@ -329,10 +340,10 @@ function resolvePathTarget(candidate: string, app: App): PathTarget | null {
     return isExistingFile(abs) ? { kind: "external", absPath: abs } : null;
   }
 
-  const file = app.vault.getAbstractFileByPath(candidate);
-  if (file instanceof TFile) return { kind: "vault", linkpath: candidate };
+  const file = app.vault.getAbstractFileByPath(norm);
+  if (file instanceof TFile) return { kind: "vault", linkpath: norm };
   // Bare names (e.g. CLAUDE.md) resolve the way Obsidian wiki-links do.
-  const dest = app.metadataCache.getFirstLinkpathDest(candidate, "");
+  const dest = app.metadataCache.getFirstLinkpathDest(norm, "");
   return dest ? { kind: "vault", linkpath: dest.path } : null;
 }
 

--- a/src/terminal-tab-manager.ts
+++ b/src/terminal-tab-manager.ts
@@ -560,13 +560,10 @@ export class TerminalTabManager {
             text: match[0],
             decorations: { pointerCursor: true, underline: true },
             activate: (event: MouseEvent) => {
-              // Cmd/Ctrl+click opens in a new tab, like Obsidian's own links.
-              const dest = this.app.metadataCache.getFirstLinkpathDest(name, "");
-              if ((event.metaKey || event.ctrlKey) && dest) {
-                void this.app.workspace.getLeaf("tab").openFile(dest);
-              } else {
-                void this.app.workspace.openLinkText(name, "", false);
-              }
+              // Cmd/Ctrl+click: open a fresh tab first, then resolve the link
+              // into it via openLinkText (which handles wiki-link resolution).
+              if (event.metaKey || event.ctrlKey) this.app.workspace.getLeaf("tab");
+              void this.app.workspace.openLinkText(name, "", false);
             },
           });
         }

--- a/src/terminal-tab-manager.ts
+++ b/src/terminal-tab-manager.ts
@@ -1,4 +1,4 @@
-import { Notice, App, FileSystemAdapter } from "obsidian";
+import { Notice, App, FileSystemAdapter, TFile } from "obsidian";
 import type { AppWithDrag, ElectronWithWebUtils, FileWithPath } from "./obsidian-internals";
 import { Terminal, type ILink } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
@@ -257,6 +257,85 @@ function extractDropPath(e: DragEvent, app: App): string | null {
   return null;
 }
 
+/** Trailing characters that are usually prose punctuation, not part of a path. */
+const PATH_TRAILING_PUNCTUATION = /[.,;:!?)\]}>'"]+$/;
+
+/**
+ * Find path-like tokens on a line: single/double-quoted strings, or unquoted
+ * runs containing a slash. Each result carries the 0-based column span of the
+ * path itself (surrounding quotes excluded) so a link range can be built.
+ */
+function findPathCandidates(text: string): { value: string; start: number; end: number }[] {
+  const results: { value: string; start: number; end: number }[] = [];
+  // 1: 'quoted'  2: "quoted"  3: unquoted path with a slash  4: bare filename.ext
+  const re =
+    /'([^']+)'|"([^"]+)"|([^\s"'`()<>]*\/[^\s"'`()<>]+)|([^\s"'`()<>/]+\.[A-Za-z0-9]{1,8})/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(text)) !== null) {
+    const quoted = match[1] ?? match[2];
+    if (quoted !== undefined) {
+      const start = match.index + 1; // skip the opening quote
+      results.push({ value: quoted, start, end: start + quoted.length });
+      continue;
+    }
+    const trimmed = (match[3] ?? match[4]).replace(PATH_TRAILING_PUNCTUATION, "");
+    if (trimmed.length === 0) continue;
+    results.push({ value: trimmed, start: match.index, end: match.index + trimmed.length });
+  }
+  return results;
+}
+
+/** A resolved path either opens inside the vault or in the system default app. */
+type PathTarget =
+  | { kind: "vault"; linkpath: string }
+  | { kind: "external"; absPath: string };
+
+/** True if the absolute path exists and is a regular file. */
+function isExistingFile(absPath: string): boolean {
+  try {
+    const fs = window.require("fs") as { statSync(p: string): { isFile(): boolean } };
+    return fs.statSync(absPath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve a path candidate to an open target, or null if it is not a real file.
+ * Vault files (relative, bare name, or absolute-inside-vault) open in Obsidian;
+ * absolute paths outside the vault open in the system default application.
+ */
+function resolvePathTarget(candidate: string, app: App): PathTarget | null {
+  let abs: string | null = null;
+  if (candidate.startsWith("/")) {
+    abs = candidate;
+  } else if (candidate.startsWith("~/")) {
+    const os = window.require("os") as { homedir(): string };
+    abs = os.homedir() + candidate.slice(1);
+  }
+
+  if (abs !== null) {
+    const adapter = app.vault.adapter;
+    if (adapter instanceof FileSystemAdapter) {
+      const base = adapter.getBasePath().split("\\").join("/");
+      const absFwd = abs.split("\\").join("/");
+      if (absFwd.startsWith(base + "/")) {
+        const rel = absFwd.slice(base.length + 1);
+        return app.vault.getAbstractFileByPath(rel) instanceof TFile
+          ? { kind: "vault", linkpath: rel }
+          : null;
+      }
+    }
+    return isExistingFile(abs) ? { kind: "external", absPath: abs } : null;
+  }
+
+  const file = app.vault.getAbstractFileByPath(candidate);
+  if (file instanceof TFile) return { kind: "vault", linkpath: candidate };
+  // Bare names (e.g. CLAUDE.md) resolve the way Obsidian wiki-links do.
+  const dest = app.metadataCache.getFirstLinkpathDest(candidate, "");
+  return dest ? { kind: "vault", linkpath: dest.path } : null;
+}
+
 export interface TabManagerOptions {
   app: App;
   tabBarEl: HTMLElement;
@@ -477,6 +556,41 @@ export class TerminalTabManager {
               void shell.openExternal(
                 `obsidian://open?vault=${encodeURIComponent(vault)}&file=${encodeURIComponent(name)}`
               );
+            },
+          });
+        }
+        callback(links);
+      },
+    });
+
+    // Bare file paths open in Obsidian (vault files) or the system app (external).
+    terminal.registerLinkProvider({
+      provideLinks: (lineNumber: number, callback: (links: ILink[] | undefined) => void) => {
+        const line = terminal.buffer.active.getLine(lineNumber - 1);
+        if (!line) { callback([]); return; }
+        const text = line.translateToString(true);
+        const links: ILink[] = [];
+        for (const candidate of findPathCandidates(text)) {
+          const target = resolvePathTarget(candidate.value, this.app);
+          if (!target) continue;
+          links.push({
+            range: {
+              start: { x: candidate.start + 1, y: lineNumber },
+              end: { x: candidate.end + 1, y: lineNumber },
+            },
+            text: candidate.value,
+            decorations: { pointerCursor: true, underline: true },
+            activate: (event: MouseEvent) => {
+              if (target.kind === "vault") {
+                // Cmd/Ctrl+click opens in a new tab, like Obsidian's own links.
+                const newLeaf = event.metaKey || event.ctrlKey ? "tab" : false;
+                void this.app.workspace.openLinkText(target.linkpath, "", newLeaf);
+              } else {
+                const { shell } = window.require("electron") as {
+                  shell: { openPath: (p: string) => Promise<string> };
+                };
+                void shell.openPath(target.absPath);
+              }
             },
           });
         }


### PR DESCRIPTION
Closes #75.

Makes bare file paths printed in the terminal clickable, complementing the existing `[[wikilink]]`, `obsidian://`, and URL link handling.

## What

A third `registerLinkProvider` (alongside the wikilink and web-link ones) linkifies path-like tokens, but only when they resolve to a real file:

- **Vault files** (vault-relative like `notes/foo.md`, a bare name like `CLAUDE.md`, or an absolute path inside the vault) open in Obsidian via `app.workspace.openLinkText`.
- **Cmd/Ctrl+click** on a vault file opens it in a **new tab** instead of the current one, matching Obsidian's own links.
- **Absolute paths outside the vault** (and `~/...`) that exist on disk open in the system default app via `shell.openPath`.

## Matching and false positives

`findPathCandidates` matches single/double-quoted strings, unquoted runs containing a slash, and bare `filename.ext` tokens. Every candidate is existence-checked (`vault.getAbstractFileByPath` / `metadataCache.getFirstLinkpathDest` for vault files, `fs.statSync().isFile()` for external), so ordinary prose is not turned into dead links. Trailing prose punctuation is stripped from unquoted tokens.

## Testing

Tested on macOS: vault-relative paths, bare root filenames, absolute in-vault paths, and external `/Users/...` and `~/...` paths all resolve and open correctly; Cmd+click opens a new tab. Non-existent paths and plain prose are left untouched.

Path resolution normalises separators to forward slashes; **Windows backslash paths are unverified** and would benefit from a tester.

Optional follow-ups if you'd like: a settings toggle (issue suggested `clickableFilePaths` off by default), an `externalEditorUri` template for the `file:line:col` case, and applying the same Cmd+click-new-tab behaviour to the existing wikilink provider for consistency. Happy to add any of these or retarget to `beta`/`work`.
