### PR TITLE
feat: public registerKeyHandler API for composable terminal key bindings (#76)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Lean Obsidian Terminal are documented here.
 
+## 1.2.0 - Unreleased
+
+### New
+
+- feat: Public `registerKeyHandler` API — companion plugins can register key handlers that compose with the built-in autocomplete/search handling, in registration order, without forking (#76)
+
 ## 1.1.2 - May 19, 2026
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -108,6 +108,45 @@ The plugin uses xterm.js for terminal rendering and node-pty for native pseudo-t
 
 On Windows, the plugin uses the ConPTY backend (correct UTF-8 and emoji support). A patched `windowsConoutConnection.js` replaces node-pty's Worker thread with inline socket piping so ConPTY works inside Obsidian's Electron renderer, which does not support Worker thread construction.
 
+## Key Handler API (for plugin developers)
+
+Companion plugins can add their own terminal key bindings — Mac-style line navigation, Vim/Emacs bindings, vendor remaps — without forking, via a small public API on the plugin instance:
+
+```ts
+registerKeyHandler(
+  handler: (e: KeyboardEvent, session: TerminalSession) => boolean
+): () => void   // returns an unregister function
+```
+
+**Execution order.** Registered handlers run in registration order, *before* the built-in autocomplete/search handling:
+
+```
+custom[0] → custom[1] → … → custom[n] → built-in autocomplete/search
+```
+
+**Return semantics.** Return `true` to let the next handler (and ultimately the built-in handling) run; return `false` to consume the event and stop the chain. Handlers see every event type (`keydown`, `keyup`, `keypress`) — filter on `e.type === "keydown"` as below. A handler that throws is logged and skipped, never breaking the chain.
+
+> **Event type note:** the handler receives the DOM `KeyboardEvent` that xterm.js passes to `attachCustomKeyEventHandler` (with `metaKey`, `altKey`, `key`, `type`, `preventDefault()`, …) — *not* xterm's internal `IKeyboardEvent`, which is not part of `@xterm/xterm`'s public type surface.
+
+**Example — Mac-style line navigation in a companion plugin:**
+
+```ts
+const leanTerm = this.app.plugins.plugins["lean-terminal"];
+const unregister = leanTerm.registerKeyHandler((e, session) => {
+  if (e.type !== "keydown") return true;
+  if (e.metaKey && e.key === "ArrowLeft")  { session.pty.write("\x01"); return false; } // ^A → start of line
+  if (e.metaKey && e.key === "ArrowRight") { session.pty.write("\x05"); return false; } // ^E → end of line
+  if (e.altKey  && e.key === "ArrowLeft")  { session.pty.write("\x1bb"); return false; } // ⎋b → back one word
+  if (e.altKey  && e.key === "ArrowRight") { session.pty.write("\x1bf"); return false; } // ⎋f → forward one word
+  return true;
+});
+
+// Call the returned disposer in your plugin's onunload():
+this.register(unregister);
+```
+
+See [Key Handler API](https://github.com/sdkasper/lean-obsidian-terminal/blob/master/docs/key-handler-api.md) for the full reference.
+
 ## Related documents
 
 See [Usage](https://github.com/sdkasper/lean-obsidian-terminal/blob/master/docs/usage.md) for the full command reference.
@@ -119,6 +158,8 @@ See [Session Persistence](https://github.com/sdkasper/lean-obsidian-terminal/blo
 See [Claude Code Integration](https://github.com/sdkasper/lean-obsidian-terminal/blob/master/docs/claude-code-integration.md) for setup and usage.
 
 See [URI Handler](https://github.com/sdkasper/lean-obsidian-terminal/blob/master/docs/uri-handler.md) for the `obsidian://lean-terminal` protocol reference.
+
+See [Key Handler API](https://github.com/sdkasper/lean-obsidian-terminal/blob/master/docs/key-handler-api.md) for the downstream key-handler registration API.
 
 See [Security](https://github.com/sdkasper/lean-obsidian-terminal/blob/master/docs/security.md) for the security review summary.
 

--- a/docs/key-handler-api.md
+++ b/docs/key-handler-api.md
@@ -1,0 +1,91 @@
+# Key Handler API
+
+Lean Terminal exposes a small public API so **other plugins** can add their own terminal key bindings — Mac-style line navigation, Vim/Emacs bindings, vendor-specific remaps — without forking the plugin or replacing its built-in `[[`-autocomplete and search handling.
+
+xterm.js only supports a single `attachCustomKeyEventHandler`, so calling it directly from another plugin would *replace* Lean Terminal's built-in handler rather than compose with it. This API solves that by maintaining an internal list of handlers that are walked before the built-in logic.
+
+## API
+
+On the plugin instance (`app.plugins.plugins["lean-terminal"]`):
+
+```ts
+registerKeyHandler(
+  handler: (e: KeyboardEvent, session: TerminalSession) => boolean
+): () => void
+```
+
+Returns an **unregister function**. Call it when your plugin unloads.
+
+### Parameters
+
+| Name | Type | Description |
+|------|------|-------------|
+| `e` | `KeyboardEvent` | The DOM keyboard event xterm.js passes to `attachCustomKeyEventHandler`. Carries the full DOM API (`metaKey`, `ctrlKey`, `altKey`, `shiftKey`, `key`, `type`, `preventDefault()`, …). Handlers receive every event type (`keydown`, `keyup`, `keypress`) — filter on `e.type`. |
+| `session` | `TerminalSession` | The terminal session the event occurred in. Use `session.pty.write(data)` to send bytes to the shell, `session.terminal` for the xterm instance, etc. |
+
+### Return value (per handler)
+
+| Return | Meaning |
+|--------|---------|
+| `true` | Not handled — continue to the next handler, and ultimately to the built-in autocomplete/search handling. |
+| `false` | Handled — **consume** the event and **stop** the chain (no further custom handlers, no built-in handling). |
+
+## Execution order
+
+Handlers run in **registration order**, before the built-in handling:
+
+```
+custom[0] → custom[1] → … → custom[n] → built-in autocomplete/search
+```
+
+The first handler to return `false` wins; everything after it (including the built-in handler) is skipped for that event.
+
+## Error isolation
+
+If a handler throws, the error is logged (`console.warn`) and the handler is skipped — the chain continues to the next handler and the terminal is unaffected. A buggy downstream handler can never crash the terminal or block other handlers.
+
+## Event type: DOM `KeyboardEvent`, not `IKeyboardEvent`
+
+The handler receives the DOM `KeyboardEvent` xterm passes to `attachCustomKeyEventHandler` — **not** xterm's internal `IKeyboardEvent`. `IKeyboardEvent` is not part of `@xterm/xterm`'s public type surface (it lives in the library's `src/common` and is not re-exported from `typings/xterm.d.ts`), so it cannot be imported from `@xterm/xterm` and would not compile. The DOM `KeyboardEvent` is what every example here relies on.
+
+## Example: Mac-style line navigation
+
+A companion plugin can add `Cmd`/`Option`+Arrow line navigation in a few lines:
+
+```ts
+export default class MacNavPlugin extends Plugin {
+  onload() {
+    const leanTerm = this.app.plugins.plugins["lean-terminal"];
+    if (!leanTerm?.registerKeyHandler) return; // Lean Terminal not installed/updated
+
+    const unregister = leanTerm.registerKeyHandler((e, session) => {
+      if (e.type !== "keydown") return true;
+      if (e.metaKey && e.key === "ArrowLeft")  { session.pty.write("\x01"); return false; } // ^A  start of line
+      if (e.metaKey && e.key === "ArrowRight") { session.pty.write("\x05"); return false; } // ^E  end of line
+      if (e.altKey  && e.key === "ArrowLeft")  { session.pty.write("\x1bb"); return false; } // ⎋b  back one word
+      if (e.altKey  && e.key === "ArrowRight") { session.pty.write("\x1bf"); return false; } // ⎋f  forward one word
+      return true;
+    });
+
+    // Ensures the handler is removed when this plugin unloads.
+    this.register(unregister);
+  }
+}
+```
+
+## Typing `TerminalSession` in your plugin
+
+`TerminalSession` and the `TerminalKeyHandler` type alias are exported from Lean Terminal's entry module for downstream typing. If you don't depend on Lean Terminal's types directly, you can model the minimal shape you use:
+
+```ts
+interface MinimalTerminalSession {
+  id: string;
+  pty: { write(data: string): void };
+  terminal: import("@xterm/xterm").Terminal;
+}
+```
+
+## Lifecycle notes
+
+- Handlers apply to **all terminal tabs**, current and future, across every terminal view/pane.
+- The registry is cleared when Lean Terminal itself unloads; you should still call your unregister function on your own plugin's unload so re-enabling your plugin doesn't double-register.

--- a/src/key-handler-registry.test.ts
+++ b/src/key-handler-registry.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { KeyHandlerRegistry, type TerminalKeyHandler } from "./key-handler-registry";
+import type { TerminalSession } from "./terminal-tab-manager";
+
+// The registry never inspects the event or session internals — only the handlers do —
+// so minimal stand-ins are sufficient and keep the test free of xterm/Obsidian runtime.
+const ev = (over: Partial<KeyboardEvent> = {}): KeyboardEvent =>
+  ({ type: "keydown", key: "a", ...over }) as unknown as KeyboardEvent;
+const session = { id: "s1" } as unknown as TerminalSession;
+
+describe("KeyHandlerRegistry", () => {
+  let reg: KeyHandlerRegistry;
+  beforeEach(() => { reg = new KeyHandlerRegistry(); });
+
+  it("dispatch with no handlers does not consume (returns true)", () => {
+    expect(reg.dispatch(ev(), session)).toBe(true);
+  });
+
+  it("passes the event and session through to the handler", () => {
+    const e = ev({ key: "ArrowLeft", altKey: true } as Partial<KeyboardEvent>);
+    const handler = vi.fn<TerminalKeyHandler>(() => true);
+    reg.register(handler);
+    reg.dispatch(e, session);
+    expect(handler).toHaveBeenCalledWith(e, session);
+  });
+
+  it("a handler returning true lets the chain fall through (dispatch true)", () => {
+    reg.register(() => true);
+    expect(reg.dispatch(ev(), session)).toBe(true);
+  });
+
+  it("a handler returning false consumes the event (dispatch false)", () => {
+    reg.register(() => false);
+    expect(reg.dispatch(ev(), session)).toBe(false);
+  });
+
+  it("runs handlers in registration order and stops at the first that consumes", () => {
+    const calls: number[] = [];
+    reg.register(() => { calls.push(1); return true; });
+    reg.register(() => { calls.push(2); return false; }); // consumes
+    reg.register(() => { calls.push(3); return true; });  // must not run
+    expect(reg.dispatch(ev(), session)).toBe(false);
+    expect(calls).toEqual([1, 2]);
+  });
+
+  it("isolates a throwing handler: logs, skips it, continues the chain", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const after = vi.fn<TerminalKeyHandler>(() => true);
+    reg.register(() => { throw new Error("boom"); });
+    reg.register(after);
+    expect(reg.dispatch(ev(), session)).toBe(true);
+    expect(after).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledOnce();
+    warn.mockRestore();
+  });
+
+  it("a throwing handler does not prevent a later handler from consuming", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    reg.register(() => { throw new Error("boom"); });
+    reg.register(() => false);
+    expect(reg.dispatch(ev(), session)).toBe(false);
+    warn.mockRestore();
+  });
+
+  it("unregister removes the handler", () => {
+    const handler = vi.fn<TerminalKeyHandler>(() => false);
+    const off = reg.register(handler);
+    off();
+    expect(reg.dispatch(ev(), session)).toBe(true); // no longer consumes
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("unregister is idempotent", () => {
+    const a = vi.fn<TerminalKeyHandler>(() => true);
+    const b = vi.fn<TerminalKeyHandler>(() => true);
+    const offA = reg.register(a);
+    reg.register(b);
+    offA();
+    offA(); // second call must be a no-op, must not remove b
+    expect(reg.size).toBe(1);
+    reg.dispatch(ev(), session);
+    expect(b).toHaveBeenCalledOnce();
+  });
+
+  it("a handler that unregisters another mid-dispatch does not corrupt iteration", () => {
+    const calls: string[] = [];
+    let offB: () => void = () => {};
+    reg.register(() => { calls.push("a"); offB(); return true; }); // removes b during dispatch
+    offB = reg.register(() => { calls.push("b"); return true; });
+    reg.register(() => { calls.push("c"); return true; });
+    // Snapshot semantics: all three present at dispatch start still run this event.
+    expect(reg.dispatch(ev(), session)).toBe(true);
+    expect(calls).toEqual(["a", "b", "c"]);
+    // But b is gone for the next event.
+    calls.length = 0;
+    reg.dispatch(ev(), session);
+    expect(calls).toEqual(["a", "c"]);
+  });
+
+  it("size reflects registrations and removals; clear empties", () => {
+    expect(reg.size).toBe(0);
+    const off1 = reg.register(() => true);
+    reg.register(() => true);
+    expect(reg.size).toBe(2);
+    off1();
+    expect(reg.size).toBe(1);
+    reg.clear();
+    expect(reg.size).toBe(0);
+    expect(reg.dispatch(ev(), session)).toBe(true);
+  });
+});

--- a/src/key-handler-registry.ts
+++ b/src/key-handler-registry.ts
@@ -1,0 +1,87 @@
+import type { TerminalSession } from "./terminal-tab-manager";
+
+/**
+ * A key handler registered by a downstream plugin via
+ * {@link TerminalPlugin.registerKeyHandler}.
+ *
+ * The handler receives the DOM {@link KeyboardEvent} that xterm.js passes to
+ * `attachCustomKeyEventHandler` — NOT xterm's internal `IKeyboardEvent`, which is
+ * not part of `@xterm/xterm`'s public type surface (it lives in `src/common` and is
+ * never re-exported from `typings/xterm.d.ts`). The event therefore carries the full
+ * DOM API (`metaKey`, `altKey`, `key`, `type`, `preventDefault()`, …) used by the
+ * example handlers in the README.
+ *
+ * Handlers see every event type (`keydown`, `keyup`, `keypress`); filter on
+ * `e.type === "keydown"` as the examples do.
+ *
+ * @param e       the keyboard event
+ * @param session the terminal session the event occurred in
+ * @returns `true` to let the next handler (and ultimately the built-in
+ *          autocomplete/search handling) run; `false` to consume the event and stop
+ *          the chain.
+ */
+export type TerminalKeyHandler = (e: KeyboardEvent, session: TerminalSession) => boolean;
+
+/**
+ * Plugin-level registry of downstream key handlers, shared across every terminal tab
+ * (current and future) in every terminal view.
+ *
+ * Dispatch order is registration order: `custom[0] → … → custom[n] → built-in`. The
+ * first handler to return `false` consumes the event; remaining handlers and the
+ * built-in autocomplete/search handling are skipped.
+ *
+ * The dispatch logic is intentionally free of any Obsidian or xterm runtime
+ * dependency so it can be unit-tested in isolation.
+ */
+export class KeyHandlerRegistry {
+  private handlers: TerminalKeyHandler[] = [];
+
+  /**
+   * Register a handler. Returns a disposer that removes it. The disposer is
+   * idempotent — calling it more than once is a no-op after the first call.
+   */
+  register(handler: TerminalKeyHandler): () => void {
+    this.handlers.push(handler);
+    let active = true;
+    return () => {
+      if (!active) return;
+      active = false;
+      const i = this.handlers.indexOf(handler);
+      if (i !== -1) this.handlers.splice(i, 1);
+    };
+  }
+
+  /**
+   * Run the registered handlers in order for one event.
+   *
+   * @returns `false` as soon as a handler consumes the event (returned `false`) — the
+   *          caller must then return `false` to xterm and skip built-in handling.
+   *          Returns `true` when no handler consumed the event.
+   *
+   * A handler that throws is logged and skipped; a misbehaving downstream handler can
+   * never break the chain or the terminal.
+   */
+  dispatch(e: KeyboardEvent, session: TerminalSession): boolean {
+    // Iterate a snapshot: a handler may unregister itself (or another) mid-dispatch,
+    // which would otherwise mutate the array we are iterating.
+    for (const handler of [...this.handlers]) {
+      try {
+        if (!handler(e, session)) return false; // consumed → stop chain
+      } catch (err) {
+        console.warn("[lean-terminal] key handler threw; skipping:", err);
+        // continue to next handler
+      }
+    }
+    return true; // not consumed → fall through to built-in handling
+  }
+
+  /** Number of currently-registered handlers. */
+  get size(): number {
+    return this.handlers.length;
+  }
+
+  /** Remove all handlers. Called on plugin unload. */
+  clear(): void {
+    this.handlers = [];
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,13 +8,45 @@ import { openRecentSessionPicker } from "./recent-sessions";
 import { refreshClaudeRegistry, resumeClaudeSession } from "./claude-sessions";
 import type { SavedViewState } from "./session-state";
 import type { TerminalTabManager } from "./terminal-tab-manager";
+import { KeyHandlerRegistry, type TerminalKeyHandler } from "./key-handler-registry";
+
+// Public API types for downstream plugins (e.g. companion key-binding plugins).
+export type { TerminalSession } from "./terminal-tab-manager";
+export type { TerminalKeyHandler } from "./key-handler-registry";
 
 export default class TerminalPlugin extends Plugin {
   settings: TerminalPluginSettings = DEFAULT_SETTINGS;
   binaryManager!: BinaryManager;
   themeRegistry!: ThemeRegistry;
+  /** Shared across every terminal view/tab; drives the public registerKeyHandler API. */
+  readonly keyHandlerRegistry = new KeyHandlerRegistry();
   private ribbonEl: HTMLElement | null = null;
   private themeObserver: MutationObserver | null = null;
+
+  /**
+   * Public API. Register a key handler invoked on every keystroke in every terminal
+   * tab — current and future — before the built-in autocomplete/search handling.
+   *
+   * Downstream usage:
+   * ```ts
+   * const leanTerm = this.app.plugins.plugins["lean-terminal"];
+   * const unregister = leanTerm.registerKeyHandler((e, session) => {
+   *   if (e.type !== "keydown") return true;
+   *   if (e.altKey && e.key === "ArrowLeft") { session.pty.write("\x1bb"); return false; }
+   *   return true;
+   * });
+   * // later, in your plugin's onunload: unregister();
+   * ```
+   *
+   * Handlers run in registration order; the first to return `false` consumes the
+   * event and stops the chain (including the built-in handler). Return `true` to pass
+   * the event along. A handler that throws is logged and skipped.
+   *
+   * @returns an unregister function (idempotent). Call it in your plugin's onunload.
+   */
+  registerKeyHandler(handler: TerminalKeyHandler): () => void {
+    return this.keyHandlerRegistry.register(handler);
+  }
 
   async onload(): Promise<void> {
     await this.loadSettings();
@@ -198,6 +230,7 @@ export default class TerminalPlugin extends Plugin {
   onunload(): void {
     this.themeObserver?.disconnect();
     this.themeObserver = null;
+    this.keyHandlerRegistry.clear();
 
     // Detach after a tick to avoid disrupting the settings modal
     window.setTimeout(() => {

--- a/src/terminal-tab-manager.ts
+++ b/src/terminal-tab-manager.ts
@@ -16,6 +16,7 @@ import { resolveShellPath } from "./settings";
 import type { BinaryManager } from "./binary-manager";
 import type { SavedTab } from "./session-state";
 import { WikiLinkAutocomplete, type AutocompleteEntry } from "./wikilink-autocomplete";
+import type { KeyHandlerRegistry } from "./key-handler-registry";
 
 const SEARCH_DECORATIONS = {
   matchBackground: "#ffff0050",
@@ -266,6 +267,8 @@ export interface TabManagerOptions {
   pluginDir: string;
   binaryManager: BinaryManager;
   themeRegistry: ThemeRegistry;
+  /** Plugin-level registry of downstream key handlers, shared across all views/tabs. */
+  keyHandlers: KeyHandlerRegistry;
   onActiveChange?: () => void;
   onTabsEmpty?: () => void;
   requestSaveLayout?: () => void;
@@ -282,6 +285,7 @@ export class TerminalTabManager {
   private pluginDir: string;
   private binaryManager: BinaryManager;
   private themeRegistry: ThemeRegistry;
+  private keyHandlers: KeyHandlerRegistry;
   private onActiveChange?: () => void;
   private onTabsEmpty?: () => void;
   private requestSaveLayout?: () => void;
@@ -301,6 +305,7 @@ export class TerminalTabManager {
     this.pluginDir = opts.pluginDir;
     this.binaryManager = opts.binaryManager;
     this.themeRegistry = opts.themeRegistry;
+    this.keyHandlers = opts.keyHandlers;
     this.onActiveChange = opts.onActiveChange;
     this.onTabsEmpty = opts.onTabsEmpty;
     this.requestSaveLayout = opts.requestSaveLayout;
@@ -605,8 +610,14 @@ export class TerminalTabManager {
 
   private installKeyHandler(terminal: Terminal, id: string): void {
     terminal.attachCustomKeyEventHandler((e: KeyboardEvent) => {
-      // Wiki-link autocomplete swallows navigation keys while its dropdown is open.
       const s = this.sessions.find((s) => s.id === id);
+
+      // Downstream-registered handlers run first, in registration order. If any
+      // returns false the event is consumed and the chain — including the built-in
+      // autocomplete/search handling below — stops. See KeyHandlerRegistry.
+      if (s && !this.keyHandlers.dispatch(e, s)) return false;
+
+      // Wiki-link autocomplete swallows navigation keys while its dropdown is open.
       if (s?.autocomplete?.handleKey(e)) return false;
 
       if (e.type !== "keydown") return true;

--- a/src/terminal-view.ts
+++ b/src/terminal-view.ts
@@ -73,6 +73,7 @@ export class TerminalView extends ItemView {
       pluginDir,
       binaryManager: this.plugin.binaryManager,
       themeRegistry: this.plugin.themeRegistry,
+      keyHandlers: this.plugin.keyHandlerRegistry,
       onTabsEmpty: () => this.leaf.detach(),
       requestSaveLayout: () => { void this.app.workspace.requestSaveLayout(); },
       onSessionClose: (tab) => { void pushRecentSession(this.plugin, tab); },


### PR DESCRIPTION
Closes #76.

Adds a plugin-public `registerKeyHandler` API so companion plugins can add terminal key bindings (Mac-style line nav, Vim/Emacs bindings, vendor remaps) that **compose with** the built-in `[[`-autocomplete and search handling, instead of replacing xterm's single `attachCustomKeyEventHandler`.

## API

```ts
registerKeyHandler(
  handler: (e: KeyboardEvent, session: TerminalSession) => boolean
): () => void   // returns an unregister function
```

Handlers run in registration order, before the built-in handling (`custom[0] → … → custom[n] → built-in`). The first to return `false` consumes the event and stops the chain; `true` passes it along.

## Addressing the four points from the issue

| # | Requested | Done |
|---|-----------|------|
| 1 | TypeScript types for the event | Typed as the DOM `KeyboardEvent` — see note below |
| 2 | Export `TerminalSession` | Re-exported from the entry module alongside `TerminalKeyHandler` |
| 3 | Error handling in the dispatcher | Per-handler `try/catch`; a throwing handler is logged (`console.warn`) and skipped, never breaking the chain |
| 4 | Documentation | New `docs/key-handler-api.md` + a README section (order, return semantics, Mac-nav example) |

## One note on the event type

The issue suggested `import { IKeyboardEvent } from '@xterm/xterm'`. I went with the DOM `KeyboardEvent` instead, because:

- `attachCustomKeyEventHandler`'s signature in xterm 5.5's public typings is `(event: KeyboardEvent) => boolean` (`node_modules/@xterm/xterm/typings/xterm.d.ts`), so a DOM `KeyboardEvent` is exactly what handlers receive.
- `IKeyboardEvent` is not exported from `@xterm/xterm`'s public types (it lives in the library's internal `src/common`), so importing it from the package would not compile.
- The DOM event is also what the example handlers in the issue rely on (`e.metaKey`, `e.altKey`, `e.code`, `e.type`).

Happy to adjust if you'd prefer a re-exported alias or a custom type instead.

## Design

- New `src/key-handler-registry.ts` — a small, dependency-free `KeyHandlerRegistry` (register / dispatch / size / clear). Dispatch iterates a snapshot so a handler can safely unregister itself mid-dispatch; the unregister disposer is idempotent.
- One registry lives on the plugin and is shared across all terminal views/tabs; `installKeyHandler` consults it before the built-in logic. Cleared on `onunload`.
- With no handlers registered, the key path is unchanged from before (the dispatch loop runs zero times and returns immediately) — zero behavior change for existing users.

## Tests

- `src/key-handler-registry.test.ts` (vitest) covers ordering, `false`-stops-chain, throw isolation, idempotent unregister, and mid-dispatch snapshot safety.
- `npm run build` (tsc + esbuild) is clean; full suite passes (81 tests).
- Verified live in a running Obsidian terminal: registered handlers receive a DOM `KeyboardEvent` for every keystroke with the correct `TerminalSession`; returning `false` consumes the event and the handler's `session.pty.write(...)` reaches the shell (tested with the Mac-style word-nav example).

## Notes

- Added a `1.2.0 - Unreleased` section to `CHANGELOG.md` for this API — happy to rename/date it to fit your release process.
- The new test file uses the existing `vitest` setup (`npm test`).
