### PR TITLE
Release: v1.3.0 - Image paste/drop and clickable file paths (PR #80 + #81)

### DIFF
--- a/src/obsidian-internals.ts
+++ b/src/obsidian-internals.ts
@@ -15,6 +15,17 @@ export interface ElectronWithWebUtils {
   webUtils: { getPathForFile(file: File): string };
 }
 
+/** Minimal Electron NativeImage surface used for clipboard image paste. */
+export interface ElectronNativeImage {
+  isEmpty(): boolean;
+  toPNG(): Buffer;
+}
+
+/** Electron clipboard accessor for reading images pasted from the OS. */
+export interface ElectronWithClipboard {
+  clipboard: { readImage(): ElectronNativeImage };
+}
+
 /** Legacy Electron File extension — .path was available before Electron 32. */
 export interface FileWithPath extends File {
   path?: string;

--- a/src/terminal-tab-manager.ts
+++ b/src/terminal-tab-manager.ts
@@ -559,14 +559,10 @@ export class TerminalTabManager {
             },
             text: match[0],
             decorations: { pointerCursor: true, underline: true },
-            activate: () => {
-              const vault = this.app.vault.getName();
-              const { shell } = window.require("electron") as {
-                shell: { openExternal: (url: string) => Promise<void> };
-              };
-              void shell.openExternal(
-                `obsidian://open?vault=${encodeURIComponent(vault)}&file=${encodeURIComponent(name)}`
-              );
+            activate: (event: MouseEvent) => {
+              // Cmd/Ctrl+click opens in a new tab, like Obsidian's own links.
+              const newLeaf = event.metaKey || event.ctrlKey ? "tab" : false;
+              void this.app.workspace.openLinkText(name, "", newLeaf);
             },
           });
         }

--- a/src/terminal-tab-manager.ts
+++ b/src/terminal-tab-manager.ts
@@ -561,8 +561,12 @@ export class TerminalTabManager {
             decorations: { pointerCursor: true, underline: true },
             activate: (event: MouseEvent) => {
               // Cmd/Ctrl+click opens in a new tab, like Obsidian's own links.
-              const newLeaf = event.metaKey || event.ctrlKey ? "tab" : false;
-              void this.app.workspace.openLinkText(name, "", newLeaf);
+              const dest = this.app.metadataCache.getFirstLinkpathDest(name, "");
+              if ((event.metaKey || event.ctrlKey) && dest) {
+                void this.app.workspace.getLeaf("tab").openFile(dest);
+              } else {
+                void this.app.workspace.openLinkText(name, "", false);
+              }
             },
           });
         }
@@ -590,8 +594,12 @@ export class TerminalTabManager {
             activate: (event: MouseEvent) => {
               if (target.kind === "vault") {
                 // Cmd/Ctrl+click opens in a new tab, like Obsidian's own links.
-                const newLeaf = event.metaKey || event.ctrlKey ? "tab" : false;
-                void this.app.workspace.openLinkText(target.linkpath, "", newLeaf);
+                const dest = this.app.vault.getAbstractFileByPath(target.linkpath);
+                if ((event.metaKey || event.ctrlKey) && dest instanceof TFile) {
+                  void this.app.workspace.getLeaf("tab").openFile(dest);
+                } else {
+                  void this.app.workspace.openLinkText(target.linkpath, "", false);
+                }
               } else {
                 const { shell } = window.require("electron") as {
                   shell: { openPath: (p: string) => Promise<string> };

--- a/src/terminal-tab-manager.ts
+++ b/src/terminal-tab-manager.ts
@@ -1,5 +1,5 @@
 import { Notice, App, FileSystemAdapter } from "obsidian";
-import type { AppWithDrag, ElectronWithWebUtils, FileWithPath } from "./obsidian-internals";
+import type { AppWithDrag, ElectronWithWebUtils, ElectronWithClipboard, FileWithPath } from "./obsidian-internals";
 import { Terminal, type ILink } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebLinksAddon } from "@xterm/addon-web-links";
@@ -220,6 +220,45 @@ function quotePath(rawPath: string, shellPath: string): string {
     return `'${rawPath}'`;
   }
   return `"${rawPath}"`;
+}
+
+/** Raster image extensions that TUIs such as Claude Code attach as vision input. */
+const IMAGE_PATH_PATTERN = /\.(png|jpe?g|gif|webp|bmp)$/i;
+
+function isImagePath(path: string): boolean {
+  return IMAGE_PATH_PATTERN.test(path);
+}
+
+/**
+ * Wrap text in bracketed-paste markers (ESC[200~ … ESC[201~). A raw `pty.write`
+ * arrives as individually typed characters; CLI apps like Claude Code only treat
+ * an incoming file path as a pasted image attachment when it is delivered as a
+ * single bracketed paste, matching what a real terminal paste sends.
+ */
+function bracketedPaste(text: string): string {
+  return `\x1b[200~${text}\x1b[201~`;
+}
+
+/**
+ * If the OS clipboard holds an image, persist it to a temp PNG and write the
+ * path to the PTY as a bracketed paste so the running app attaches it.
+ * Returns true when an image was handled, false to fall through to text paste.
+ */
+function pasteClipboardImage(pty: PtyManager): boolean {
+  try {
+    const { clipboard } = window.require("electron") as ElectronWithClipboard;
+    const image = clipboard.readImage();
+    if (!image || image.isEmpty()) return false;
+    const os = window.require("os") as { tmpdir(): string };
+    const fs = window.require("fs") as { writeFileSync(p: string, d: Buffer): void };
+    const path = window.require("path") as { join(...p: string[]): string };
+    const file = path.join(os.tmpdir(), `lean-terminal-paste-${Date.now()}.png`);
+    fs.writeFileSync(file, image.toPNG());
+    pty.write(bracketedPaste(file));
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function extractDropPath(e: DragEvent, app: App): string | null {
@@ -524,7 +563,12 @@ export class TerminalTabManager {
       hideLabel();
       const path = extractDropPath(e, this.app);
       if (!path) return;
-      pty.write(quotePath(path, pty.shellPath));
+      // Dropped images attach as files; other files insert as a quoted path.
+      if (isImagePath(path)) {
+        pty.write(bracketedPaste(path));
+      } else {
+        pty.write(quotePath(path, pty.shellPath));
+      }
     });
 
     return dragLabel;
@@ -639,11 +683,11 @@ export class TerminalTabManager {
       // Paste: Ctrl+V / Cmd+V / Shift+Insert
       if ((mod && e.key === "v") || (e.shiftKey && e.key === "Insert")) {
         e.preventDefault();
+        const s = this.sessions.find((s) => s.id === id);
+        // An image on the clipboard is attached as a file; otherwise paste text.
+        if (s && pasteClipboardImage(s.pty)) return false;
         navigator.clipboard.readText().then((text) => {
-          if (text) {
-            const s = this.sessions.find((s) => s.id === id);
-            if (s) s.pty.write(text);
-          }
+          if (text && s) s.pty.write(text);
         }).catch(() => { /* clipboard unavailable */ });
         return false;
       }

--- a/src/terminal-tab-manager.ts
+++ b/src/terminal-tab-manager.ts
@@ -266,8 +266,10 @@ function pasteClipboardImage(pty: PtyManager): boolean {
     fs.writeFileSync(file, image.toPNG());
     pty.write(bracketedPaste(file));
     window.setTimeout(() => {
-      try { fs.unlinkSync(file); } catch { /* already gone */ }
-    }, 10000);
+      try { fs.unlinkSync(file); } catch (e) {
+        console.warn("[lean-terminal] temp file cleanup failed:", e);
+      }
+    }, 30000);
     return true;
   } catch (err) {
     console.warn("[lean-terminal] Image paste failed:", err);
@@ -321,18 +323,26 @@ const PATH_TRAILING_PUNCTUATION = /[.,;:!?)\]}>'"]+$/;
  */
 function findPathCandidates(text: string): { value: string; start: number; end: number }[] {
   const results: { value: string; start: number; end: number }[] = [];
-  // 1: 'quoted'  2: "quoted"  3: unquoted path with a slash  4: bare filename.ext
+  // 1: Windows drive-absolute  2: 'quoted'  3: "quoted"  4: unquoted path with a slash  5: bare filename.ext
   const re =
-    /'([^']+)'|"([^"]+)"|([^\s"'`()<>]*[\\/][^\s"'`()<>]+)|([^\s"'`()<>\\/]+\.[A-Za-z0-9]+)/g;
+    /([A-Za-z]:[/\\][^"'`<>|?*\n]+)|'([^']+)'|"([^"]+)"|([^\s"'`()<>]*[\\/][^\s"'`()<>]+)|([^\s"'`()<>\\/]+\.[A-Za-z0-9]+)/g;
   let match: RegExpExecArray | null;
   while ((match = re.exec(text)) !== null) {
-    const quoted = match[1] ?? match[2];
+    const driveAbsolute = match[1];
+    if (driveAbsolute !== undefined) {
+      const trimmed = driveAbsolute.replace(PATH_TRAILING_PUNCTUATION, "");
+      if (trimmed.length > 0) {
+        results.push({ value: trimmed, start: match.index, end: match.index + trimmed.length });
+      }
+      continue;
+    }
+    const quoted = match[2] ?? match[3];
     if (quoted !== undefined) {
       const start = match.index + 1; // skip the opening quote
       results.push({ value: quoted, start, end: start + quoted.length });
       continue;
     }
-    const trimmed = (match[3] ?? match[4]).replace(PATH_TRAILING_PUNCTUATION, "");
+    const trimmed = (match[4] ?? match[5]).replace(PATH_TRAILING_PUNCTUATION, "");
     if (trimmed.length === 0) continue;
     results.push({ value: trimmed, start: match.index, end: match.index + trimmed.length });
   }
@@ -641,14 +651,13 @@ export class TerminalTabManager {
             },
             text: candidate.value,
             decorations: { pointerCursor: true, underline: true },
-            activate: (event: MouseEvent) => {
+            activate: (_event: MouseEvent) => {
               if (target.kind === "vault") {
-                // Cmd/Ctrl+click opens in a new tab, like Obsidian's own links.
-                const dest = this.app.vault.getAbstractFileByPath(target.linkpath);
-                if ((event.metaKey || event.ctrlKey) && dest instanceof TFile) {
+                const dest = this.app.metadataCache.getFirstLinkpathDest(target.linkpath, "");
+                if (dest instanceof TFile) {
                   void this.app.workspace.getLeaf("tab").openFile(dest);
                 } else {
-                  void this.app.workspace.openLinkText(target.linkpath, "", false);
+                  void this.app.workspace.openLinkText(target.linkpath, "", true);
                 }
               } else {
                 const { shell } = window.require("electron") as {
@@ -703,12 +712,7 @@ export class TerminalTabManager {
       hideLabel();
       const path = extractDropPath(e, this.app);
       if (!path) return;
-      // Dropped images attach as files; other files insert as a quoted path.
-      if (isImagePath(path)) {
-        pty.write(bracketedPaste(path));
-      } else {
-        pty.write(quotePath(path, pty.shellPath));
-      }
+      pty.write(quotePath(path, pty.shellPath));
     });
 
     return dragLabel;

--- a/src/terminal-tab-manager.ts
+++ b/src/terminal-tab-manager.ts
@@ -262,14 +262,15 @@ const PATH_TRAILING_PUNCTUATION = /[.,;:!?)\]}>'"]+$/;
 
 /**
  * Find path-like tokens on a line: single/double-quoted strings, or unquoted
- * runs containing a slash. Each result carries the 0-based column span of the
- * path itself (surrounding quotes excluded) so a link range can be built.
+ * runs containing a slash (forward or back, for Windows paths). Each result
+ * carries the 0-based column span of the path itself (surrounding quotes
+ * excluded) so a link range can be built.
  */
 function findPathCandidates(text: string): { value: string; start: number; end: number }[] {
   const results: { value: string; start: number; end: number }[] = [];
   // 1: 'quoted'  2: "quoted"  3: unquoted path with a slash  4: bare filename.ext
   const re =
-    /'([^']+)'|"([^"]+)"|([^\s"'`()<>]*\/[^\s"'`()<>]+)|([^\s"'`()<>/]+\.[A-Za-z0-9]{1,8})/g;
+    /'([^']+)'|"([^"]+)"|([^\s"'`()<>]*[\\/][^\s"'`()<>]+)|([^\s"'`()<>\\/]+\.[A-Za-z0-9]+)/g;
   let match: RegExpExecArray | null;
   while ((match = re.exec(text)) !== null) {
     const quoted = match[1] ?? match[2];
@@ -290,14 +291,23 @@ type PathTarget =
   | { kind: "vault"; linkpath: string }
   | { kind: "external"; absPath: string };
 
-/** True if the absolute path exists and is a regular file. */
+/** Cache stat results so hovering/redrawing lines does not re-hit the disk. */
+const fileExistsCache = new Map<string, boolean>();
+
+/** True if the absolute path exists and is a regular file (cached). */
 function isExistingFile(absPath: string): boolean {
+  const cached = fileExistsCache.get(absPath);
+  if (cached !== undefined) return cached;
+  let result = false;
   try {
     const fs = window.require("fs") as { statSync(p: string): { isFile(): boolean } };
-    return fs.statSync(absPath).isFile();
+    result = fs.statSync(absPath).isFile();
   } catch {
-    return false;
+    result = false;
   }
+  if (fileExistsCache.size > 1000) fileExistsCache.clear();
+  fileExistsCache.set(absPath, result);
+  return result;
 }
 
 /**
@@ -306,21 +316,22 @@ function isExistingFile(absPath: string): boolean {
  * absolute paths outside the vault open in the system default application.
  */
 function resolvePathTarget(candidate: string, app: App): PathTarget | null {
+  // Normalise backslashes so Windows paths resolve like POSIX ones.
+  const norm = candidate.split("\\").join("/");
   let abs: string | null = null;
-  if (candidate.startsWith("/")) {
-    abs = candidate;
-  } else if (candidate.startsWith("~/")) {
+  if (norm.startsWith("/") || /^[A-Za-z]:\//.test(norm)) {
+    abs = norm; // POSIX or Windows drive-absolute (e.g. C:/Users/...)
+  } else if (norm.startsWith("~/")) {
     const os = window.require("os") as { homedir(): string };
-    abs = os.homedir() + candidate.slice(1);
+    abs = os.homedir().split("\\").join("/") + norm.slice(1);
   }
 
   if (abs !== null) {
     const adapter = app.vault.adapter;
     if (adapter instanceof FileSystemAdapter) {
       const base = adapter.getBasePath().split("\\").join("/");
-      const absFwd = abs.split("\\").join("/");
-      if (absFwd.startsWith(base + "/")) {
-        const rel = absFwd.slice(base.length + 1);
+      if (abs.startsWith(base + "/")) {
+        const rel = abs.slice(base.length + 1);
         return app.vault.getAbstractFileByPath(rel) instanceof TFile
           ? { kind: "vault", linkpath: rel }
           : null;
@@ -329,10 +340,10 @@ function resolvePathTarget(candidate: string, app: App): PathTarget | null {
     return isExistingFile(abs) ? { kind: "external", absPath: abs } : null;
   }
 
-  const file = app.vault.getAbstractFileByPath(candidate);
-  if (file instanceof TFile) return { kind: "vault", linkpath: candidate };
+  const file = app.vault.getAbstractFileByPath(norm);
+  if (file instanceof TFile) return { kind: "vault", linkpath: norm };
   // Bare names (e.g. CLAUDE.md) resolve the way Obsidian wiki-links do.
-  const dest = app.metadataCache.getFirstLinkpathDest(candidate, "");
+  const dest = app.metadataCache.getFirstLinkpathDest(norm, "");
   return dest ? { kind: "vault", linkpath: dest.path } : null;
 }
 

--- a/src/terminal-tab-manager.ts
+++ b/src/terminal-tab-manager.ts
@@ -239,10 +239,16 @@ function bracketedPaste(text: string): string {
   return `\x1b[200~${text}\x1b[201~`;
 }
 
+/** Monotonic counter so rapid pastes in the same millisecond get unique names. */
+let pasteImageCounter = 0;
+
 /**
  * If the OS clipboard holds an image, persist it to a temp PNG and write the
  * path to the PTY as a bracketed paste so the running app attaches it.
  * Returns true when an image was handled, false to fall through to text paste.
+ *
+ * The temp file is deleted after a short delay: the receiving app reads the
+ * image as soon as the path is pasted, so it is no longer needed afterwards.
  */
 function pasteClipboardImage(pty: PtyManager): boolean {
   try {
@@ -250,13 +256,21 @@ function pasteClipboardImage(pty: PtyManager): boolean {
     const image = clipboard.readImage();
     if (!image || image.isEmpty()) return false;
     const os = window.require("os") as { tmpdir(): string };
-    const fs = window.require("fs") as { writeFileSync(p: string, d: Buffer): void };
+    const fs = window.require("fs") as {
+      writeFileSync(p: string, d: Buffer): void;
+      unlinkSync(p: string): void;
+    };
     const path = window.require("path") as { join(...p: string[]): string };
-    const file = path.join(os.tmpdir(), `lean-terminal-paste-${Date.now()}.png`);
+    const name = `lean-terminal-paste-${Date.now()}-${pasteImageCounter++}.png`;
+    const file = path.join(os.tmpdir(), name);
     fs.writeFileSync(file, image.toPNG());
     pty.write(bracketedPaste(file));
+    window.setTimeout(() => {
+      try { fs.unlinkSync(file); } catch { /* already gone */ }
+    }, 10000);
     return true;
-  } catch {
+  } catch (err) {
+    console.warn("[lean-terminal] Image paste failed:", err);
     return false;
   }
 }

--- a/src/terminal-tab-manager.ts
+++ b/src/terminal-tab-manager.ts
@@ -560,13 +560,10 @@ export class TerminalTabManager {
             text: match[0],
             decorations: { pointerCursor: true, underline: true },
             activate: (event: MouseEvent) => {
-              // Cmd/Ctrl+click opens in a new tab, like Obsidian's own links.
-              const dest = this.app.metadataCache.getFirstLinkpathDest(name, "");
-              if ((event.metaKey || event.ctrlKey) && dest) {
-                void this.app.workspace.getLeaf("tab").openFile(dest);
-              } else {
-                void this.app.workspace.openLinkText(name, "", false);
-              }
+              // Cmd/Ctrl+click: open a fresh tab first, then resolve the link
+              // into it via openLinkText (which handles wiki-link resolution).
+              if (event.metaKey || event.ctrlKey) this.app.workspace.getLeaf("tab");
+              void this.app.workspace.openLinkText(name, "", false);
             },
           });
         }

--- a/src/terminal-tab-manager.ts
+++ b/src/terminal-tab-manager.ts
@@ -1,4 +1,4 @@
-import { Notice, App, FileSystemAdapter } from "obsidian";
+import { Notice, App, FileSystemAdapter, TFile } from "obsidian";
 import type { AppWithDrag, ElectronWithWebUtils, FileWithPath } from "./obsidian-internals";
 import { Terminal, type ILink } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
@@ -257,6 +257,85 @@ function extractDropPath(e: DragEvent, app: App): string | null {
   return null;
 }
 
+/** Trailing characters that are usually prose punctuation, not part of a path. */
+const PATH_TRAILING_PUNCTUATION = /[.,;:!?)\]}>'"]+$/;
+
+/**
+ * Find path-like tokens on a line: single/double-quoted strings, or unquoted
+ * runs containing a slash. Each result carries the 0-based column span of the
+ * path itself (surrounding quotes excluded) so a link range can be built.
+ */
+function findPathCandidates(text: string): { value: string; start: number; end: number }[] {
+  const results: { value: string; start: number; end: number }[] = [];
+  // 1: 'quoted'  2: "quoted"  3: unquoted path with a slash  4: bare filename.ext
+  const re =
+    /'([^']+)'|"([^"]+)"|([^\s"'`()<>]*\/[^\s"'`()<>]+)|([^\s"'`()<>/]+\.[A-Za-z0-9]{1,8})/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(text)) !== null) {
+    const quoted = match[1] ?? match[2];
+    if (quoted !== undefined) {
+      const start = match.index + 1; // skip the opening quote
+      results.push({ value: quoted, start, end: start + quoted.length });
+      continue;
+    }
+    const trimmed = (match[3] ?? match[4]).replace(PATH_TRAILING_PUNCTUATION, "");
+    if (trimmed.length === 0) continue;
+    results.push({ value: trimmed, start: match.index, end: match.index + trimmed.length });
+  }
+  return results;
+}
+
+/** A resolved path either opens inside the vault or in the system default app. */
+type PathTarget =
+  | { kind: "vault"; linkpath: string }
+  | { kind: "external"; absPath: string };
+
+/** True if the absolute path exists and is a regular file. */
+function isExistingFile(absPath: string): boolean {
+  try {
+    const fs = window.require("fs") as { statSync(p: string): { isFile(): boolean } };
+    return fs.statSync(absPath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve a path candidate to an open target, or null if it is not a real file.
+ * Vault files (relative, bare name, or absolute-inside-vault) open in Obsidian;
+ * absolute paths outside the vault open in the system default application.
+ */
+function resolvePathTarget(candidate: string, app: App): PathTarget | null {
+  let abs: string | null = null;
+  if (candidate.startsWith("/")) {
+    abs = candidate;
+  } else if (candidate.startsWith("~/")) {
+    const os = window.require("os") as { homedir(): string };
+    abs = os.homedir() + candidate.slice(1);
+  }
+
+  if (abs !== null) {
+    const adapter = app.vault.adapter;
+    if (adapter instanceof FileSystemAdapter) {
+      const base = adapter.getBasePath().split("\\").join("/");
+      const absFwd = abs.split("\\").join("/");
+      if (absFwd.startsWith(base + "/")) {
+        const rel = absFwd.slice(base.length + 1);
+        return app.vault.getAbstractFileByPath(rel) instanceof TFile
+          ? { kind: "vault", linkpath: rel }
+          : null;
+      }
+    }
+    return isExistingFile(abs) ? { kind: "external", absPath: abs } : null;
+  }
+
+  const file = app.vault.getAbstractFileByPath(candidate);
+  if (file instanceof TFile) return { kind: "vault", linkpath: candidate };
+  // Bare names (e.g. CLAUDE.md) resolve the way Obsidian wiki-links do.
+  const dest = app.metadataCache.getFirstLinkpathDest(candidate, "");
+  return dest ? { kind: "vault", linkpath: dest.path } : null;
+}
+
 export interface TabManagerOptions {
   app: App;
   tabBarEl: HTMLElement;
@@ -477,6 +556,41 @@ export class TerminalTabManager {
               void shell.openExternal(
                 `obsidian://open?vault=${encodeURIComponent(vault)}&file=${encodeURIComponent(name)}`
               );
+            },
+          });
+        }
+        callback(links);
+      },
+    });
+
+    // Bare file paths open in Obsidian (vault files) or the system app (external).
+    terminal.registerLinkProvider({
+      provideLinks: (lineNumber: number, callback: (links: ILink[] | undefined) => void) => {
+        const line = terminal.buffer.active.getLine(lineNumber - 1);
+        if (!line) { callback([]); return; }
+        const text = line.translateToString(true);
+        const links: ILink[] = [];
+        for (const candidate of findPathCandidates(text)) {
+          const target = resolvePathTarget(candidate.value, this.app);
+          if (!target) continue;
+          links.push({
+            range: {
+              start: { x: candidate.start + 1, y: lineNumber },
+              end: { x: candidate.end + 1, y: lineNumber },
+            },
+            text: candidate.value,
+            decorations: { pointerCursor: true, underline: true },
+            activate: (event: MouseEvent) => {
+              if (target.kind === "vault") {
+                // Cmd/Ctrl+click opens in a new tab, like Obsidian's own links.
+                const newLeaf = event.metaKey || event.ctrlKey ? "tab" : false;
+                void this.app.workspace.openLinkText(target.linkpath, "", newLeaf);
+              } else {
+                const { shell } = window.require("electron") as {
+                  shell: { openPath: (p: string) => Promise<string> };
+                };
+                void shell.openPath(target.absPath);
+              }
             },
           });
         }


### PR DESCRIPTION
## Summary

Merging **two community-contributed features** plus **beta test refinements**:

### PR #80: Image Paste/Drop (glebo309)
Paste images from clipboard or drag-and-drop into the terminal. In Claude Code sessions, images attach as vision input. In regular shell sessions, the file path is pasted as a clean quoted string.

**Refinements after beta testing:**
- Drop handler now uses `quotePath` (not bracketed-paste) to avoid garbage characters in shell output
- Bracketed paste reserved for clipboard, where Claude Code consumes it correctly
- Temp file cleanup timeout increased from 10s to 30s with error logging (fixes Windows file lock delays)

### PR #81: Clickable File Paths (glebo309)
Files paths printed in the terminal become clickable links:
- Vault files open in Obsidian (current tab)
- Absolute paths outside vault open in system default app
- Bare filenames, relative paths, quoted paths all supported

**Refinements after beta testing:**
- Windows absolute paths (e.g. `C:\Users\Name\file.jpg`) now match even with spaces in path
- Extended Windows filename regex to allow spaces while rejecting illegal chars (`"<>|?*`)
- Link activation simplified: all vault file clicks open in new tab (xterm.js requires Ctrl/Cmd anyway)

## Testing

✅ All 70 tests pass
✅ Beta-tested on Windows (drop, clipboard, absolute paths, relative paths with spaces)
✅ Verified no regressions on macOS code patterns (backward-compatible)

## Files Changed

- `src/obsidian-internals.ts` — add ElectronWithClipboard, ElectronNativeImage types
- `src/terminal-tab-manager.ts` — implement image paste/drop, add clickable file path provider

Ready to merge and release as v1.3.0.