### PR TITLE
Fix: resolve merge conflict markers

### DIFF
--- a/src/terminal-tab-manager.ts
+++ b/src/terminal-tab-manager.ts
@@ -267,15 +267,10 @@ function pasteClipboardImage(pty: PtyManager): boolean {
     fs.writeFileSync(file, image.toPNG());
     pty.write(bracketedPaste(file));
     window.setTimeout(() => {
-<<<<<<< HEAD
       try { fs.unlinkSync(file); } catch (e) {
         console.warn("[lean-terminal] temp file cleanup failed:", e);
       }
     }, 30000);
-=======
-      try { fs.unlinkSync(file); } catch { /* already gone */ }
-    }, 10000);
->>>>>>> origin/master
     return true;
   } catch (err) {
     console.warn("[lean-terminal] Image paste failed:", err);


### PR DESCRIPTION
Remove unresolved conflict markers from terminal-tab-manager.ts left by PR #83 merge.

Uses the correct version: 30s timeout with error logging for temp file cleanup (the feedback-fixed version from the beta branch).