### PR TITLE
Fix: replace deprecated activeLeaf API

### DIFF
--- a/src/terminal-view.ts
+++ b/src/terminal-view.ts
@@ -16,6 +16,8 @@ export class TerminalView extends ItemView {
    * Applied in onOpen() once the manager is ready.
    */
   private pendingState: SavedViewState | null = null;
+  /** Tracks whether this leaf is currently active. */
+  private isActive = false;
 
   constructor(leaf: WorkspaceLeaf, plugin: TerminalPlugin) {
     super(leaf);
@@ -97,7 +99,7 @@ export class TerminalView extends ItemView {
       this.resizeTimer = window.setTimeout(() => {
         this.tabManager?.fitActive();
         // Only restore focus if this leaf is active; prevent stealing focus during unrelated pane resizes
-        if (this.app.workspace.activeLeaf === this.leaf) {
+        if (this.isActive) {
           this.tabManager?.focusActive();
         }
       }, 50);
@@ -107,6 +109,7 @@ export class TerminalView extends ItemView {
     // Restore focus when this leaf becomes active (e.g. switching from another detached window)
     this.registerEvent(
       this.app.workspace.on("active-leaf-change", (leaf) => {
+        this.isActive = leaf === this.leaf;
         if (!leaf || leaf !== this.leaf) return;
         // Defer so Obsidian's own leaf-switch focus logic completes first (prevents racing command palette)
         window.setTimeout(() => this.tabManager?.focusActive(), 0);


### PR DESCRIPTION
Replace deprecated Workspace.activeLeaf with local state tracking.

## Changes
- Added isActive boolean to track whether this leaf is active
- Updated via existing active-leaf-change event listener
- Replaced activeLeaf check in resize observer with isActive check

## Obsidian Review Feedback
The submission for plugin review flagged activeLeaf as deprecated. The recommended alternatives are:
- If you need information about the current view, use Workspace.getActiveViewOfType()
- If you need to open a new file or navigate a view, use Workspace.getLeaf()

In this case, we only need to know if our leaf is active, so tracking that via the active-leaf-change event is the cleanest approach.