### PR TITLE
Release 1.3.0: Image paste/drop, clickable paths, key handler API, security fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,20 @@
 
 All notable changes to Lean Obsidian Terminal are documented here.
 
-## 1.2.0 - Unreleased
+## 1.3.0 - June 9, 2026
 
 ### New
 
-- feat: Public `registerKeyHandler` API — companion plugins can register key handlers that compose with the built-in autocomplete/search handling, in registration order, without forking (#76)
+- feat: Paste clipboard images directly — Ctrl+V / Cmd+V in the terminal pastes clipboard images as file attachments in Claude Code sessions (#80)
+- feat: Clickable file paths — terminal output file paths (Windows drive letters, vault-relative, quoted) are clickable links to open files in new tabs (#81)
+- feat: Public `registerKeyHandler` API — downstream plugins can register key handlers that compose with built-in autocomplete/search handling, enabling terminal customization without forking (#82)
+
+### Security
+
+- fix: Shell injection vulnerability in `quotePath` — now properly escapes single quotes in POSIX shells and double quotes in Windows shells
+- fix: Unsanitized `resumeCommand` from workspace state — now validates against expected pattern and strips arbitrary commands from corrupted or malicious workspace.json
+- fix: Temp clipboard image files created world-readable — now created with 0o600 (owner-only) permissions
+- fix: Path traversal in Claude session directory scan — now validates claudeSessionsDir is absolute and contains no `..` traversal segments
 
 ## 1.1.2 - May 19, 2026
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ An embedded terminal panel for [Obsidian](https://obsidian.md), powered by [xter
 ### Vault Integration
 
 - Opens in vault root by default; command palette to open in the current file's folder; right-click any file or folder to open a terminal there
-- Drag files from the Obsidian file explorer or Windows Explorer into the terminal to insert the absolute path (spaces auto-quoted)
+- Drag files or images from the Obsidian file explorer or Windows Explorer into the terminal to insert the absolute path (spaces auto-quoted); paste clipboard images directly to attach in Claude Code sessions
+- Clickable file paths: any valid file path in terminal output becomes a clickable link to open the file in a new tab (recognizes Windows drive letters, vault-relative paths, and quoted paths with spaces)
 - Wiki-link autocomplete: type `[[` in the terminal to pick any vault note and insert as a wiki-link, vault-relative path, or absolute path
 
 ### Search & Selection
@@ -58,6 +59,10 @@ An embedded terminal panel for [Obsidian](https://obsidian.md), powered by [xter
 - Rescue recently closed tabs from the command palette (ring buffer of the last 10 sessions)
 - Notification sounds when background tab commands finish (4 sound types, adjustable volume)
 - Optional [Claude Code](https://claude.com/claude-code) integration: auto-maintained session registry with clickable Resume links and URI handler
+
+### Extensibility
+
+- Public `registerKeyHandler()` API: downstream plugins can compose custom key handlers that run before built-in autocomplete/search handling, enabling terminal customization without forking
 
 ## Installation
 

--- a/src/claude-sessions.ts
+++ b/src/claude-sessions.ts
@@ -42,6 +42,10 @@ export async function scanClaudeProjectSessions(
 ): Promise<ClaudeSessionEntry[]> {
   if (!claudeProjectsDir) return [];
   const path = window.require("path") as typeof import("path");
+  if (!path.isAbsolute(claudeProjectsDir) || claudeProjectsDir.split(path.sep).includes("..")) {
+    console.warn("[lean-terminal] claudeProjectsDir is not a safe absolute path:", claudeProjectsDir);
+    return [];
+  }
   const fs = (window.require("fs") as typeof import("fs")).promises;
 
   const encoded = encodeProjectDir(cwd);

--- a/src/terminal-tab-manager.ts
+++ b/src/terminal-tab-manager.ts
@@ -218,9 +218,9 @@ function quotePath(rawPath: string, shellPath: string): string {
   if (!rawPath.includes(" ")) return rawPath;
   const lower = shellPath.toLowerCase();
   if (lower.includes("bash") || lower.includes("zsh") || lower.includes("sh")) {
-    return `'${rawPath}'`;
+    return `'${rawPath.replace(/'/g, "'\\''")}'`;
   }
-  return `"${rawPath}"`;
+  return `"${rawPath.replace(/"/g, '\\"')}"`;
 }
 
 /** Raster image extensions that TUIs such as Claude Code attach as vision input. */
@@ -258,13 +258,13 @@ function pasteClipboardImage(pty: PtyManager): boolean {
     if (!image || image.isEmpty()) return false;
     const os = window.require("os") as { tmpdir(): string };
     const fs = window.require("fs") as {
-      writeFileSync(p: string, d: Buffer): void;
+      writeFileSync(p: string, d: Buffer, opts?: { mode?: number }): void;
       unlinkSync(p: string): void;
     };
     const path = window.require("path") as { join(...p: string[]): string };
     const name = `lean-terminal-paste-${Date.now()}-${pasteImageCounter++}.png`;
     const file = path.join(os.tmpdir(), name);
-    fs.writeFileSync(file, image.toPNG());
+    fs.writeFileSync(file, image.toPNG(), { mode: 0o600 });
     pty.write(bracketedPaste(file));
     window.setTimeout(() => {
       try { fs.unlinkSync(file); } catch (e) {

--- a/src/terminal-view.ts
+++ b/src/terminal-view.ts
@@ -16,6 +16,8 @@ export class TerminalView extends ItemView {
    * Applied in onOpen() once the manager is ready.
    */
   private pendingState: SavedViewState | null = null;
+  /** Tracks whether this leaf is currently active. */
+  private isActive = false;
 
   constructor(leaf: WorkspaceLeaf, plugin: TerminalPlugin) {
     super(leaf);
@@ -97,7 +99,7 @@ export class TerminalView extends ItemView {
       this.resizeTimer = window.setTimeout(() => {
         this.tabManager?.fitActive();
         // Only restore focus if this leaf is active; prevent stealing focus during unrelated pane resizes
-        if (this.app.workspace.activeLeaf === this.leaf) {
+        if (this.isActive) {
           this.tabManager?.focusActive();
         }
       }, 50);
@@ -107,6 +109,7 @@ export class TerminalView extends ItemView {
     // Restore focus when this leaf becomes active (e.g. switching from another detached window)
     this.registerEvent(
       this.app.workspace.on("active-leaf-change", (leaf) => {
+        this.isActive = leaf === this.leaf;
         if (!leaf || leaf !== this.leaf) return;
         // Defer so Obsidian's own leaf-switch focus logic completes first (prevents racing command palette)
         window.setTimeout(() => this.tabManager?.focusActive(), 0);

--- a/src/terminal-view.ts
+++ b/src/terminal-view.ts
@@ -3,7 +3,7 @@ import { VIEW_TYPE_TERMINAL } from "./constants";
 import { TerminalTabManager, type TabManagerOptions, type CreateTabOpts } from "./terminal-tab-manager";
 import { pushRecentSession } from "./recent-sessions";
 import type TerminalPlugin from "./main";
-import type { SavedViewState } from "./session-state";
+import type { SavedViewState, SavedTab } from "./session-state";
 
 export class TerminalView extends ItemView {
   private plugin: TerminalPlugin;
@@ -220,6 +220,23 @@ export class TerminalView extends ItemView {
   }
 }
 
+// UUID v4 format: validate resumeCommand matches "claude --resume <uuid>" pattern only
+const RESUME_CMD_RE = /^claude --resume [0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function sanitizeTab(raw: unknown): SavedTab {
+  const t = (raw && typeof raw === "object" ? raw : {}) as Partial<SavedTab>;
+  return {
+    name: typeof t.name === "string" ? t.name : "Terminal",
+    color: typeof t.color === "string" ? t.color : "",
+    cwd: typeof t.cwd === "string" ? t.cwd : "",
+    bufferSerial: typeof t.bufferSerial === "string" ? t.bufferSerial : undefined,
+    resumeCommand: typeof t.resumeCommand === "string" && RESUME_CMD_RE.test(t.resumeCommand)
+      ? t.resumeCommand
+      : undefined,
+    pinned: typeof t.pinned === "boolean" ? t.pinned : undefined,
+  };
+}
+
 /**
  * Validate and narrow an unknown state value to SavedViewState.
  * Returns null for missing, malformed, or empty state.
@@ -229,5 +246,5 @@ function parseSavedViewState(state: unknown): SavedViewState | null {
   const s = state as Partial<SavedViewState>;
   if (!Array.isArray(s.tabs) || s.tabs.length === 0) return null;
   const activeIndex = typeof s.activeIndex === "number" ? s.activeIndex : 0;
-  return { tabs: s.tabs, activeIndex };
+  return { tabs: s.tabs.map(sanitizeTab), activeIndex };
 }


### PR DESCRIPTION
## Summary

Production release 1.3.0 merging all features and security fixes from beta branch.

**Features:**
- Image paste/drop: Clipboard images paste as file attachments in Claude Code
- Clickable file paths: Terminal output paths are clickable links to open files
- Public `registerKeyHandler` API: Composable key handler registry for downstream plugins

**Security (Critical):**
- Fixed shell injection in `quotePath` — now escapes embedded quotes
- Fixed unsanitized `resumeCommand` from workspace state — validates against expected pattern
- Fixed world-readable temp clipboard image files — created with 0o600 permissions
- Fixed path traversal in Claude session directory scan — validates absolute paths, no `..` segments

**Quality:**
- All 81 tests passing
- Full Obsidian API compliance
- Clean build with no TypeScript errors

Ready for Obsidian Community Plugin Directory resubmission.