### PR TITLE
fix: open file links that carry a :line[:col] suffix

### DIFF
--- a/src/path-links.test.ts
+++ b/src/path-links.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { findPathCandidates, splitLineSuffix } from "./path-links";
+
+describe("findPathCandidates", () => {
+  const values = (text: string): string[] => findPathCandidates(text).map((c) => c.value);
+
+  it("keeps a :line suffix on a path with a slash", () => {
+    expect(values("edit src/main.ts:42 please")).toEqual(["src/main.ts:42"]);
+  });
+
+  it("keeps a :line suffix on a BARE filename (the common tsc/grep shape)", () => {
+    // Regression guard: group 5 previously stopped at the ':' and dropped the line.
+    expect(values("open CLAUDE.md:5 now")).toEqual(["CLAUDE.md:5"]);
+    expect(values("index.ts:42")).toEqual(["index.ts:42"]);
+  });
+
+  it("keeps a :line:col suffix (tsc error format)", () => {
+    expect(values("main.ts:10:5 - error TS2345")).toEqual(["main.ts:10:5"]);
+  });
+
+  it("still matches a bare filename with no line suffix", () => {
+    expect(values("see config.json for details")).toEqual(["config.json"]);
+  });
+
+  it("captures quoted paths and Windows drive-absolute paths", () => {
+    expect(values('open "my file.ts:9" ok')).toEqual(["my file.ts:9"]);
+    expect(values("C:/Users/x/file.ts:42")).toEqual(["C:/Users/x/file.ts:42"]);
+  });
+
+  it("strips trailing prose punctuation", () => {
+    expect(values("look at notes.md.")).toEqual(["notes.md"]);
+  });
+});
+
+describe("splitLineSuffix", () => {
+  it("returns the candidate unchanged when there is no line suffix", () => {
+    expect(splitLineSuffix("src/main.ts")).toEqual({ path: "src/main.ts", line: null });
+    expect(splitLineSuffix("CLAUDE.md")).toEqual({ path: "CLAUDE.md", line: null });
+  });
+
+  it("peels a trailing :line suffix", () => {
+    expect(splitLineSuffix("src/main.ts:42")).toEqual({ path: "src/main.ts", line: 42 });
+  });
+
+  it("peels a trailing :line:col suffix, keeping the line", () => {
+    expect(splitLineSuffix("src/main.ts:42:10")).toEqual({ path: "src/main.ts", line: 42 });
+  });
+
+  it("does not mistake a Windows drive colon for a line separator", () => {
+    expect(splitLineSuffix("C:/Users/x/file.ts")).toEqual({ path: "C:/Users/x/file.ts", line: null });
+    expect(splitLineSuffix("C:/Users/x/file.ts:42")).toEqual({ path: "C:/Users/x/file.ts", line: 42 });
+  });
+
+  it("strips the suffix but nulls the line for out-of-range values (0 / overflow)", () => {
+    // Path is still peeled so the file can open — just without a bogus line jump.
+    expect(splitLineSuffix("file.ts:0")).toEqual({ path: "file.ts", line: null });
+    expect(splitLineSuffix("file.ts:99999999999999999999")).toEqual({ path: "file.ts", line: null });
+  });
+
+  it("does not treat a dotted version fragment as a line", () => {
+    expect(splitLineSuffix("v1.2.3")).toEqual({ path: "v1.2.3", line: null });
+  });
+});

--- a/src/path-links.ts
+++ b/src/path-links.ts
@@ -1,0 +1,69 @@
+/**
+ * Pure helpers for turning clicked terminal path tokens into open actions.
+ *
+ * This module holds only pure string transforms (no `obsidian`/`@xterm` imports),
+ * so it can be unit-tested directly — the terminal module pulls in xterm, which
+ * needs a DOM and cannot be imported under the node test environment. The
+ * stateful, filesystem/vault-aware resolution (`resolvePathTarget`) stays in
+ * terminal-tab-manager.ts.
+ */
+
+/** Trailing characters that are usually prose punctuation, not part of a path. */
+const PATH_TRAILING_PUNCTUATION = /[.,;:!?)\]}>'"]+$/;
+
+/**
+ * Find path-like tokens on a line: single/double-quoted strings, unquoted runs
+ * containing a slash (forward or back, for Windows paths), or a bare
+ * `filename.ext` — each optionally followed by a `:line[:col]` suffix. Each result
+ * carries the 0-based column span of the token (surrounding quotes excluded) so a
+ * link range can be built.
+ */
+export function findPathCandidates(text: string): { value: string; start: number; end: number }[] {
+  const results: { value: string; start: number; end: number }[] = [];
+  // 1: Windows drive-absolute  2: 'quoted'  3: "quoted"  4: unquoted path with a slash
+  // 5: bare filename.ext with an optional :line[:col] suffix (slash paths already
+  //    keep the suffix via group 4's colon-inclusive class; group 5 must opt in).
+  const re =
+    /([A-Za-z]:[/\\][^"'`<>|?*\n]+)|'([^']+)'|"([^"]+)"|([^\s"'`()<>]*[\\/][^\s"'`()<>]+)|([^\s"'`()<>\\/]+\.[A-Za-z0-9]+(?::\d+(?::\d+)?)?)/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(text)) !== null) {
+    const driveAbsolute = match[1];
+    if (driveAbsolute !== undefined) {
+      const trimmed = driveAbsolute.replace(PATH_TRAILING_PUNCTUATION, "");
+      if (trimmed.length > 0) {
+        results.push({ value: trimmed, start: match.index, end: match.index + trimmed.length });
+      }
+      continue;
+    }
+    const quoted = match[2] ?? match[3];
+    if (quoted !== undefined) {
+      const start = match.index + 1; // skip the opening quote
+      results.push({ value: quoted, start, end: start + quoted.length });
+      continue;
+    }
+    const trimmed = (match[4] ?? match[5]).replace(PATH_TRAILING_PUNCTUATION, "");
+    if (trimmed.length === 0) continue;
+    results.push({ value: trimmed, start: match.index, end: match.index + trimmed.length });
+  }
+  return results;
+}
+
+/**
+ * Split a trailing `:line` or `:line:col` suffix off a path candidate. Editors,
+ * compilers, grep, and TUIs such as Claude Code print file references as
+ * `path:line[:col]`; the suffix must be removed before the path can resolve to a
+ * real file. Returns the bare path and the 1-based line, or `line: null` when
+ * there is no suffix OR the number is out of range (0, negative, or beyond the
+ * safe-integer range) — in which case the path is still stripped so the file can
+ * open, just without a line jump.
+ *
+ * The path group is lazy so a Windows drive letter (`C:/…`) or a mid-path colon is
+ * not mistaken for a line separator — only a trailing `:digits[:digits]` is.
+ */
+export function splitLineSuffix(candidate: string): { path: string; line: number | null } {
+  const match = /^(.*?):(\d+)(?::\d+)?$/.exec(candidate);
+  if (!match) return { path: candidate, line: null };
+  const parsed = Number(match[2]);
+  const line = Number.isSafeInteger(parsed) && parsed >= 1 ? parsed : null;
+  return { path: match[1], line };
+}

--- a/src/terminal-tab-manager.ts
+++ b/src/terminal-tab-manager.ts
@@ -7,6 +7,7 @@ import { SerializeAddon } from "@xterm/addon-serialize";
 import { SearchAddon } from "@xterm/addon-search";
 import type { IDisposable } from "@xterm/xterm";
 import { PtyManager } from "./pty-manager";
+import { findPathCandidates, splitLineSuffix } from "./path-links";
 import { isObsidianDark } from "./themes";
 import { mixHex } from "./color-utils";
 import { findTabColor, DEFAULT_TINT_STRENGTH, MAX_TINT_STRENGTH } from "./tab-colors";
@@ -313,42 +314,6 @@ function extractDropPath(e: DragEvent, app: App): string | null {
   return null;
 }
 
-/** Trailing characters that are usually prose punctuation, not part of a path. */
-const PATH_TRAILING_PUNCTUATION = /[.,;:!?)\]}>'"]+$/;
-
-/**
- * Find path-like tokens on a line: single/double-quoted strings, or unquoted
- * runs containing a slash (forward or back, for Windows paths). Each result
- * carries the 0-based column span of the path itself (surrounding quotes
- * excluded) so a link range can be built.
- */
-function findPathCandidates(text: string): { value: string; start: number; end: number }[] {
-  const results: { value: string; start: number; end: number }[] = [];
-  // 1: Windows drive-absolute  2: 'quoted'  3: "quoted"  4: unquoted path with a slash  5: bare filename.ext
-  const re =
-    /([A-Za-z]:[/\\][^"'`<>|?*\n]+)|'([^']+)'|"([^"]+)"|([^\s"'`()<>]*[\\/][^\s"'`()<>]+)|([^\s"'`()<>\\/]+\.[A-Za-z0-9]+)/g;
-  let match: RegExpExecArray | null;
-  while ((match = re.exec(text)) !== null) {
-    const driveAbsolute = match[1];
-    if (driveAbsolute !== undefined) {
-      const trimmed = driveAbsolute.replace(PATH_TRAILING_PUNCTUATION, "");
-      if (trimmed.length > 0) {
-        results.push({ value: trimmed, start: match.index, end: match.index + trimmed.length });
-      }
-      continue;
-    }
-    const quoted = match[2] ?? match[3];
-    if (quoted !== undefined) {
-      const start = match.index + 1; // skip the opening quote
-      results.push({ value: quoted, start, end: start + quoted.length });
-      continue;
-    }
-    const trimmed = (match[4] ?? match[5]).replace(PATH_TRAILING_PUNCTUATION, "");
-    if (trimmed.length === 0) continue;
-    results.push({ value: trimmed, start: match.index, end: match.index + trimmed.length });
-  }
-  return results;
-}
 
 /** A resolved path either opens inside the vault or in the system default app. */
 type PathTarget =
@@ -647,8 +612,24 @@ export class TerminalTabManager {
         const text = line.translateToString(true);
         const links: ILink[] = [];
         for (const candidate of findPathCandidates(text)) {
-          const target = resolvePathTarget(candidate.value, this.app);
+          // Resolve the raw token first (so a file literally named "foo:42" still
+          // wins); only if that fails, retry after peeling a trailing :line[:col]
+          // suffix (e.g. "src/main.ts:42") and carry the line through so the file
+          // opens at that position.
+          let target = resolvePathTarget(candidate.value, this.app);
+          let targetLine: number | null = null;
+          if (!target) {
+            const { path, line } = splitLineSuffix(candidate.value);
+            if (path !== candidate.value) {
+              const stripped = resolvePathTarget(path, this.app);
+              if (stripped) {
+                target = stripped;
+                targetLine = line;
+              }
+            }
+          }
           if (!target) continue;
+          const resolved = target;
           links.push({
             range: {
               start: { x: candidate.start + 1, y: lineNumber },
@@ -657,18 +638,20 @@ export class TerminalTabManager {
             text: candidate.value,
             decorations: { pointerCursor: true, underline: true },
             activate: (_event: MouseEvent) => {
-              if (target.kind === "vault") {
-                const dest = this.app.metadataCache.getFirstLinkpathDest(target.linkpath, "");
+              if (resolved.kind === "vault") {
+                const dest = this.app.metadataCache.getFirstLinkpathDest(resolved.linkpath, "");
                 if (dest instanceof TFile) {
-                  void this.app.workspace.getLeaf("tab").openFile(dest);
+                  const viewState =
+                    targetLine != null ? { eState: { line: targetLine - 1 } } : undefined;
+                  void this.app.workspace.getLeaf("tab").openFile(dest, viewState);
                 } else {
-                  void this.app.workspace.openLinkText(target.linkpath, "", true);
+                  void this.app.workspace.openLinkText(resolved.linkpath, "", true);
                 }
               } else {
                 const { shell } = window.require("electron") as {
                   shell: { openPath: (p: string) => Promise<string> };
                 };
-                void shell.openPath(target.absPath);
+                void shell.openPath(resolved.absPath);
               }
             },
           });


### PR DESCRIPTION
## What does this PR do?

Fixes clickable file paths that carry a `:line[:col]` suffix (e.g. `src/main.ts:42`) — previously the suffix was treated as part of the filename, so the link silently failed to resolve.

## Details

Terminal output from compilers, `grep`, `tsc`, and similar tools prints file references as `path:line` or `path:line:col`. The link provider treated the whole token as the path, so `resolvePathTarget` couldn't find the file and no link was created (or it opened the wrong path). Slash-containing paths kept the suffix via the colon-inclusive class, but bare filenames like `CLAUDE.md:5` dropped it at the scanner — so the feature worked for `src/main.ts:42` but not root-level references, which is confusingly inconsistent.

- Moves the pure `findPathCandidates` into a new `src/path-links.ts` so it can be unit-tested (the terminal module imports xterm and needs a DOM), and widens its bare-filename branch to keep a trailing `:line[:col]`.
- Adds `splitLineSuffix`: peel the suffix, retry resolution on the bare path, and carry the 1-based line through. Out-of-range values (`:0`, overflow) still open the file, just without a jump.
- Vault markdown files open at the resolved line via `openFile` eState.
- New `src/path-links.test.ts` covers the scanner and the split (Windows drive-colon, `:line:col`, out-of-range, bare vs slash paths).

## Checklist

- [x] `npm run build` passes locally
- [x] No existing features removed
- [x] `terminal-tab-manager.ts` was modified — the change is confined to the bare-path link provider (plus moving `findPathCandidates` out to a new module). Tab pinning, drag-and-drop, search, copy-on-select, and tab reordering are not touched. Verified via `tsc`, unit tests, and a production build; I have not re-run manual in-app QA of those subsystems.
- [x] No new dependencies

## Features removed (if any)

None.
