### PR TITLE
feat: configurable command to open external file links in a terminal tab

### DIFF
--- a/src/path-links.test.ts
+++ b/src/path-links.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { findPathCandidates, splitLineSuffix } from "./path-links";
+
+describe("findPathCandidates", () => {
+  const values = (text: string): string[] => findPathCandidates(text).map((c) => c.value);
+
+  it("keeps a :line suffix on a path with a slash", () => {
+    expect(values("edit src/main.ts:42 please")).toEqual(["src/main.ts:42"]);
+  });
+
+  it("keeps a :line suffix on a BARE filename (the common tsc/grep shape)", () => {
+    // Regression guard: group 5 previously stopped at the ':' and dropped the line.
+    expect(values("open CLAUDE.md:5 now")).toEqual(["CLAUDE.md:5"]);
+    expect(values("index.ts:42")).toEqual(["index.ts:42"]);
+  });
+
+  it("keeps a :line:col suffix (tsc error format)", () => {
+    expect(values("main.ts:10:5 - error TS2345")).toEqual(["main.ts:10:5"]);
+  });
+
+  it("still matches a bare filename with no line suffix", () => {
+    expect(values("see config.json for details")).toEqual(["config.json"]);
+  });
+
+  it("captures quoted paths and Windows drive-absolute paths", () => {
+    expect(values('open "my file.ts:9" ok')).toEqual(["my file.ts:9"]);
+    expect(values("C:/Users/x/file.ts:42")).toEqual(["C:/Users/x/file.ts:42"]);
+  });
+
+  it("strips trailing prose punctuation", () => {
+    expect(values("look at notes.md.")).toEqual(["notes.md"]);
+  });
+});
+
+describe("splitLineSuffix", () => {
+  it("returns the candidate unchanged when there is no line suffix", () => {
+    expect(splitLineSuffix("src/main.ts")).toEqual({ path: "src/main.ts", line: null });
+    expect(splitLineSuffix("CLAUDE.md")).toEqual({ path: "CLAUDE.md", line: null });
+  });
+
+  it("peels a trailing :line suffix", () => {
+    expect(splitLineSuffix("src/main.ts:42")).toEqual({ path: "src/main.ts", line: 42 });
+  });
+
+  it("peels a trailing :line:col suffix, keeping the line", () => {
+    expect(splitLineSuffix("src/main.ts:42:10")).toEqual({ path: "src/main.ts", line: 42 });
+  });
+
+  it("does not mistake a Windows drive colon for a line separator", () => {
+    expect(splitLineSuffix("C:/Users/x/file.ts")).toEqual({ path: "C:/Users/x/file.ts", line: null });
+    expect(splitLineSuffix("C:/Users/x/file.ts:42")).toEqual({ path: "C:/Users/x/file.ts", line: 42 });
+  });
+
+  it("strips the suffix but nulls the line for out-of-range values (0 / overflow)", () => {
+    // Path is still peeled so the file can open — just without a bogus line jump.
+    expect(splitLineSuffix("file.ts:0")).toEqual({ path: "file.ts", line: null });
+    expect(splitLineSuffix("file.ts:99999999999999999999")).toEqual({ path: "file.ts", line: null });
+  });
+
+  it("does not treat a dotted version fragment as a line", () => {
+    expect(splitLineSuffix("v1.2.3")).toEqual({ path: "v1.2.3", line: null });
+  });
+});

--- a/src/path-links.test.ts
+++ b/src/path-links.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { findPathCandidates, splitLineSuffix } from "./path-links";
+import { execFileSync } from "node:child_process";
+import {
+  findPathCandidates,
+  splitLineSuffix,
+  shellQuoteAlways,
+  buildExternalCommand,
+  externalCommandMissingFile,
+} from "./path-links";
 
 describe("findPathCandidates", () => {
   const values = (text: string): string[] => findPathCandidates(text).map((c) => c.value);
@@ -60,4 +67,124 @@ describe("splitLineSuffix", () => {
   it("does not treat a dotted version fragment as a line", () => {
     expect(splitLineSuffix("v1.2.3")).toEqual({ path: "v1.2.3", line: null });
   });
+});
+
+describe("shellQuoteAlways", () => {
+  it("single-quotes for POSIX shells, and for an UNKNOWN/empty shell (safe default)", () => {
+    expect(shellQuoteAlways("/a/b/c.ts", "/bin/zsh")).toBe("'/a/b/c.ts'");
+    expect(shellQuoteAlways("/a/b/c.ts", "/bin/bash")).toBe("'/a/b/c.ts'");
+    // Empty shell path = the real default before any shell is configured. Must NOT
+    // fall to a double-quote branch (which an interpolating shell would expand).
+    expect(shellQuoteAlways("/a/b/c.ts", "")).toBe("'/a/b/c.ts'");
+  });
+
+  it("neutralizes shell metacharacters in POSIX single quotes", () => {
+    expect(shellQuoteAlways("/a/$(rm -rf ~)/c.ts", "/bin/zsh")).toBe("'/a/$(rm -rf ~)/c.ts'");
+    expect(shellQuoteAlways("/a/`id`/c.ts", "/bin/bash")).toBe("'/a/`id`/c.ts'");
+    expect(shellQuoteAlways("/a/$HOME/c.ts", "/bin/sh")).toBe("'/a/$HOME/c.ts'");
+    expect(shellQuoteAlways("/a/x; rm/c.ts", "/bin/bash")).toBe("'/a/x; rm/c.ts'");
+  });
+
+  it("escapes embedded single quotes for POSIX shells", () => {
+    expect(shellQuoteAlways("/a/it's/c.ts", "/bin/sh")).toBe("'/a/it'\\''s/c.ts'");
+  });
+
+  it("uses basename, not substring — C:/Users/Josh/cmd.exe is cmd, not POSIX", () => {
+    // "Josh" and the ".exe" path contain "sh"; a substring check would misroute it.
+    expect(shellQuoteAlways("C:/a b/c.ts", "C:/Users/Josh/cmd.exe")).toBe('"C:/a b/c.ts"');
+  });
+
+  it("doubles embedded single quotes for PowerShell (not the bash escape)", () => {
+    expect(shellQuoteAlways("C:/it's/c.ts", "powershell.exe")).toBe("'C:/it''s/c.ts'");
+    expect(shellQuoteAlways("C:/a b/c.ts", "C:/Program Files/PowerShell/7/pwsh.exe")).toBe(
+      "'C:/a b/c.ts'",
+    );
+  });
+
+  it("double-quotes for cmd.exe (neutralizing & | < >)", () => {
+    expect(shellQuoteAlways("C:/a b/c.ts", "cmd.exe")).toBe('"C:/a b/c.ts"');
+    expect(shellQuoteAlways("C:/a&b/c.ts", "cmd.exe")).toBe('"C:/a&b/c.ts"');
+  });
+});
+
+describe("buildExternalCommand", () => {
+  it("substitutes %F (quoted path) and %L (line)", () => {
+    expect(buildExternalCommand("micro +%L -- %F", "/a/b.ts", 42, "/bin/zsh")).toBe(
+      "micro +42 -- '/a/b.ts'",
+    );
+  });
+
+  it("defaults %L to 1 when no line is known", () => {
+    expect(buildExternalCommand("micro +%L -- %F", "/a/b.ts", null, "/bin/zsh")).toBe(
+      "micro +1 -- '/a/b.ts'",
+    );
+  });
+
+  it("does not re-interpret placeholder-looking characters inside the path", () => {
+    expect(buildExternalCommand("micro +%L -- %F", "/a/%Lb.ts", 7, "/bin/bash")).toBe(
+      "micro +7 -- '/a/%Lb.ts'",
+    );
+  });
+
+  it("supports multiple occurrences of each placeholder", () => {
+    expect(buildExternalCommand("echo %L; open %F %F", "/a/b.ts", 3, "/bin/zsh")).toBe(
+      "echo 3; open '/a/b.ts' '/a/b.ts'",
+    );
+  });
+});
+
+describe("externalCommandMissingFile", () => {
+  it("is false for an empty template and for one containing %F", () => {
+    expect(externalCommandMissingFile("")).toBe(false);
+    expect(externalCommandMissingFile("   ")).toBe(false);
+    expect(externalCommandMissingFile("micro +%L -- %F")).toBe(false);
+  });
+
+  it("is true for a non-empty template without %F", () => {
+    expect(externalCommandMissingFile("micro +%L")).toBe(true);
+  });
+});
+
+// Contract test: prove the quoted path survives a REAL POSIX shell as exactly one
+// literal argument — the ultimate check that shellQuoteAlways prevents injection.
+// Runs only where bash is available (ubuntu CI + macOS); skipped on Windows.
+// --noprofile --norc AND a cleared BASH_ENV: non-interactive bash still sources
+// $BASH_ENV even with --norc (some setups point it at a shell-integration script
+// that emits OSC markers), so clear it to test pure bash quoting/parsing.
+const cleanBashEnv = { ...process.env, BASH_ENV: "", ENV: "" };
+const hasBash = (() => {
+  try {
+    execFileSync("bash", ["--noprofile", "--norc", "-c", "true"], { env: cleanBashEnv });
+    return true;
+  } catch {
+    return false;
+  }
+})();
+
+describe.skipIf(!hasBash)("shellQuoteAlways — real bash round-trip", () => {
+  const roundTrip = (path: string): string =>
+    execFileSync(
+      "bash",
+      ["--noprofile", "--norc", "-c", `printf %s ${shellQuoteAlways(path, "/bin/bash")}`],
+      { encoding: "utf8", env: cleanBashEnv },
+    );
+
+  const adversarial = [
+    "/tmp/plain.ts",
+    "/tmp/with space.ts",
+    "/tmp/$(touch pwned).ts",
+    "/tmp/`touch pwned`.ts",
+    "/tmp/$HOME.ts",
+    "/tmp/a;rm -rf b.ts",
+    "/tmp/a&&b.ts",
+    "/tmp/it's a file.ts",
+    "/tmp/quote\"and'both.ts",
+    "/tmp/pipe|redirect>.ts",
+  ];
+
+  for (const path of adversarial) {
+    it(`passes ${JSON.stringify(path)} through as a single literal argument`, () => {
+      expect(roundTrip(path)).toBe(path);
+    });
+  }
 });

--- a/src/path-links.ts
+++ b/src/path-links.ts
@@ -67,3 +67,78 @@ export function splitLineSuffix(candidate: string): { path: string; line: number
   const line = Number.isSafeInteger(parsed) && parsed >= 1 ? parsed : null;
   return { path: match[1], line };
 }
+
+/** Shell families with distinct string-quoting rules. */
+type ShellFamily = "posix" | "powershell" | "cmd";
+
+/**
+ * Classify a shell by its binary basename (NOT a substring of the full path — a
+ * path like `C:\Users\Josh\cmd.exe` must not be read as POSIX because it contains
+ * "sh"). An unknown or empty shell falls back to POSIX, whose single-quoting never
+ * allows expansion and is therefore the safe default.
+ */
+function shellFamily(shellPath: string): ShellFamily {
+  const base = (shellPath.toLowerCase().replace(/\\/g, "/").split("/").pop() ?? "").replace(
+    /\.exe$/,
+    "",
+  );
+  if (base === "pwsh" || base === "powershell") return "powershell";
+  if (base === "cmd") return "cmd";
+  return "posix"; // bash/zsh/sh/dash/fish/ksh/… and the safe default for unknown
+}
+
+/**
+ * Quote a path so it survives as a single literal argument in the given shell.
+ * Always quotes (unlike `quotePath`, which skips paths without spaces), so paths
+ * containing shell metacharacters — `$(…)`, backticks, `$VAR`, `;`, `&`, spaces,
+ * `%VAR%` — cannot be interpreted by the shell the command is typed into.
+ */
+export function shellQuoteAlways(rawPath: string, shellPath: string): string {
+  switch (shellFamily(shellPath)) {
+    case "powershell":
+      // PowerShell single-quoted literal: an embedded ' is escaped by doubling it.
+      // (Backslash is NOT an escape char in PowerShell, so the POSIX trick is wrong.)
+      return `'${rawPath.replace(/'/g, "''")}'`;
+    case "cmd":
+      // cmd.exe: double quotes group the injection metacharacters (& | < > ( ) ^),
+      // and " is illegal in Windows filenames (escaped defensively regardless).
+      // Known limitation: %VAR% still expands inside cmd double quotes; there is no
+      // reliable interactive-cmd escape for a literal %, so a filename containing
+      // %NAME% matching an env var may open the wrong path. This is a correctness
+      // edge, not an injection vector (expansion yields literal text inside quotes).
+      return `"${rawPath.replace(/"/g, '\\"')}"`;
+    case "posix":
+    default:
+      // POSIX single-quoted literal: close-quote, escaped quote, reopen-quote.
+      return `'${rawPath.replace(/'/g, "'\\''")}'`;
+  }
+}
+
+/**
+ * Build the command run in a new terminal tab for an external file by substituting
+ * placeholders in the user's `externalFileCommand` template:
+ *   %F — shell-quoted absolute path
+ *   %L — 1-based line number (1 when the link carried no line)
+ * A single pass is used so characters inside the substituted path are never
+ * re-interpreted as placeholders.
+ */
+export function buildExternalCommand(
+  template: string,
+  absPath: string,
+  line: number | null,
+  shellPath: string,
+): string {
+  return template.replace(/%[FL]/g, (token) =>
+    token === "%F"
+      ? shellQuoteAlways(absPath, shellPath)
+      : line != null
+        ? String(line)
+        : "1",
+  );
+}
+
+/** True if a non-empty external-file command template lacks the required `%F`. */
+export function externalCommandMissingFile(template: string): boolean {
+  const trimmed = template.trim();
+  return trimmed.length > 0 && !trimmed.includes("%F");
+}

--- a/src/path-links.ts
+++ b/src/path-links.ts
@@ -1,0 +1,69 @@
+/**
+ * Pure helpers for turning clicked terminal path tokens into open actions.
+ *
+ * This module holds only pure string transforms (no `obsidian`/`@xterm` imports),
+ * so it can be unit-tested directly — the terminal module pulls in xterm, which
+ * needs a DOM and cannot be imported under the node test environment. The
+ * stateful, filesystem/vault-aware resolution (`resolvePathTarget`) stays in
+ * terminal-tab-manager.ts.
+ */
+
+/** Trailing characters that are usually prose punctuation, not part of a path. */
+const PATH_TRAILING_PUNCTUATION = /[.,;:!?)\]}>'"]+$/;
+
+/**
+ * Find path-like tokens on a line: single/double-quoted strings, unquoted runs
+ * containing a slash (forward or back, for Windows paths), or a bare
+ * `filename.ext` — each optionally followed by a `:line[:col]` suffix. Each result
+ * carries the 0-based column span of the token (surrounding quotes excluded) so a
+ * link range can be built.
+ */
+export function findPathCandidates(text: string): { value: string; start: number; end: number }[] {
+  const results: { value: string; start: number; end: number }[] = [];
+  // 1: Windows drive-absolute  2: 'quoted'  3: "quoted"  4: unquoted path with a slash
+  // 5: bare filename.ext with an optional :line[:col] suffix (slash paths already
+  //    keep the suffix via group 4's colon-inclusive class; group 5 must opt in).
+  const re =
+    /([A-Za-z]:[/\\][^"'`<>|?*\n]+)|'([^']+)'|"([^"]+)"|([^\s"'`()<>]*[\\/][^\s"'`()<>]+)|([^\s"'`()<>\\/]+\.[A-Za-z0-9]+(?::\d+(?::\d+)?)?)/g;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(text)) !== null) {
+    const driveAbsolute = match[1];
+    if (driveAbsolute !== undefined) {
+      const trimmed = driveAbsolute.replace(PATH_TRAILING_PUNCTUATION, "");
+      if (trimmed.length > 0) {
+        results.push({ value: trimmed, start: match.index, end: match.index + trimmed.length });
+      }
+      continue;
+    }
+    const quoted = match[2] ?? match[3];
+    if (quoted !== undefined) {
+      const start = match.index + 1; // skip the opening quote
+      results.push({ value: quoted, start, end: start + quoted.length });
+      continue;
+    }
+    const trimmed = (match[4] ?? match[5]).replace(PATH_TRAILING_PUNCTUATION, "");
+    if (trimmed.length === 0) continue;
+    results.push({ value: trimmed, start: match.index, end: match.index + trimmed.length });
+  }
+  return results;
+}
+
+/**
+ * Split a trailing `:line` or `:line:col` suffix off a path candidate. Editors,
+ * compilers, grep, and TUIs such as Claude Code print file references as
+ * `path:line[:col]`; the suffix must be removed before the path can resolve to a
+ * real file. Returns the bare path and the 1-based line, or `line: null` when
+ * there is no suffix OR the number is out of range (0, negative, or beyond the
+ * safe-integer range) — in which case the path is still stripped so the file can
+ * open, just without a line jump.
+ *
+ * The path group is lazy so a Windows drive letter (`C:/…`) or a mid-path colon is
+ * not mistaken for a line separator — only a trailing `:digits[:digits]` is.
+ */
+export function splitLineSuffix(candidate: string): { path: string; line: number | null } {
+  const match = /^(.*?):(\d+)(?::\d+)?$/.exec(candidate);
+  if (!match) return { path: candidate, line: null };
+  const parsed = Number(match[2]);
+  const line = Number.isSafeInteger(parsed) && parsed >= 1 ? parsed : null;
+  return { path: match[1], line };
+}

--- a/src/pty-manager.ts
+++ b/src/pty-manager.ts
@@ -37,7 +37,8 @@ function loadNodePty(pluginDir: string): NodePtyModule {
   }
 }
 
-function getDefaultShell(): string {
+/** The shell binary a new PTY will spawn when no explicit shellPath is set. */
+export function getDefaultShell(): string {
   if (Platform.isWin) {
     const pwshPaths = [
       process.env.ProgramFiles + "\\PowerShell\\7\\pwsh.exe",                    // standard installer

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -7,6 +7,7 @@ import {
   MAX_TINT_STRENGTH,
   type TabColorDef,
 } from "./tab-colors";
+import { externalCommandMissingFile } from "./path-links";
 
 export type NotificationSound = "beep" | "chime" | "ping" | "pop";
 
@@ -27,6 +28,12 @@ export interface TerminalPluginSettings {
   shellPathMac: string;
   shellPathLinux: string;
   startupCommand: string;
+  /**
+   * Command run in a new terminal tab to open a clicked file that lives outside
+   * the vault. Empty = open with the OS default application. Placeholders:
+   * `%F` (shell-quoted absolute path), `%L` (1-based line, 1 if unknown).
+   */
+  externalFileCommand: string;
   fontSize: number;
   fontFamily: string;
   lineHeight: number;
@@ -65,6 +72,7 @@ export const DEFAULT_SETTINGS: TerminalPluginSettings = {
   shellPathMac: "",
   shellPathLinux: "",
   startupCommand: "",
+  externalFileCommand: "",
   fontSize: 14,
   fontFamily: "Menlo, Monaco, 'Courier New', monospace",
   lineHeight: 1.0,
@@ -378,6 +386,30 @@ export class TerminalSettingTab extends PluginSettingTab {
             await this.plugin.saveSettings();
           })
       );
+
+    new Setting(containerEl)
+      .setName("External file open command")
+      .setDesc(
+        "Command run in a new terminal tab when you click a file link outside the vault. " +
+          "Leave empty to open with the OS default app. Placeholders: %F = file path, %L = line number. " +
+          "Example: micro +%L -- %F",
+      )
+      .addText((text) => {
+        text
+          .setPlaceholder("none")
+          .setValue(this.plugin.settings.externalFileCommand)
+          .onChange(async (value) => {
+            this.plugin.settings.externalFileCommand = value;
+            await this.plugin.saveSettings();
+          });
+        // Warn once (on blur, not per keystroke) if a non-empty command omits %F,
+        // which would open the editor on no file — a confusing silent no-op.
+        text.inputEl.addEventListener("blur", () => {
+          if (externalCommandMissingFile(this.plugin.settings.externalFileCommand)) {
+            new Notice("External file command has no %F — the file path won't be passed.");
+          }
+        });
+      });
 
     new Setting(containerEl)
       .setName("Default location")

--- a/src/terminal-tab-manager.ts
+++ b/src/terminal-tab-manager.ts
@@ -7,6 +7,7 @@ import { SerializeAddon } from "@xterm/addon-serialize";
 import { SearchAddon } from "@xterm/addon-search";
 import type { IDisposable } from "@xterm/xterm";
 import { PtyManager } from "./pty-manager";
+import { findPathCandidates, splitLineSuffix } from "./path-links";
 import { isObsidianDark } from "./themes";
 import { mixHex } from "./color-utils";
 import { findTabColor, DEFAULT_TINT_STRENGTH, MAX_TINT_STRENGTH } from "./tab-colors";
@@ -313,42 +314,6 @@ function extractDropPath(e: DragEvent, app: App): string | null {
   return null;
 }
 
-/** Trailing characters that are usually prose punctuation, not part of a path. */
-const PATH_TRAILING_PUNCTUATION = /[.,;:!?)\]}>'"]+$/;
-
-/**
- * Find path-like tokens on a line: single/double-quoted strings, or unquoted
- * runs containing a slash (forward or back, for Windows paths). Each result
- * carries the 0-based column span of the path itself (surrounding quotes
- * excluded) so a link range can be built.
- */
-function findPathCandidates(text: string): { value: string; start: number; end: number }[] {
-  const results: { value: string; start: number; end: number }[] = [];
-  // 1: Windows drive-absolute  2: 'quoted'  3: "quoted"  4: unquoted path with a slash  5: bare filename.ext
-  const re =
-    /([A-Za-z]:[/\\][^"'`<>|?*\n]+)|'([^']+)'|"([^"]+)"|([^\s"'`()<>]*[\\/][^\s"'`()<>]+)|([^\s"'`()<>\\/]+\.[A-Za-z0-9]+)/g;
-  let match: RegExpExecArray | null;
-  while ((match = re.exec(text)) !== null) {
-    const driveAbsolute = match[1];
-    if (driveAbsolute !== undefined) {
-      const trimmed = driveAbsolute.replace(PATH_TRAILING_PUNCTUATION, "");
-      if (trimmed.length > 0) {
-        results.push({ value: trimmed, start: match.index, end: match.index + trimmed.length });
-      }
-      continue;
-    }
-    const quoted = match[2] ?? match[3];
-    if (quoted !== undefined) {
-      const start = match.index + 1; // skip the opening quote
-      results.push({ value: quoted, start, end: start + quoted.length });
-      continue;
-    }
-    const trimmed = (match[4] ?? match[5]).replace(PATH_TRAILING_PUNCTUATION, "");
-    if (trimmed.length === 0) continue;
-    results.push({ value: trimmed, start: match.index, end: match.index + trimmed.length });
-  }
-  return results;
-}
 
 /** A resolved path either opens inside the vault or in the system default app. */
 type PathTarget =
@@ -647,8 +612,24 @@ export class TerminalTabManager {
         const text = line.translateToString(true);
         const links: ILink[] = [];
         for (const candidate of findPathCandidates(text)) {
-          const target = resolvePathTarget(candidate.value, this.app);
+          // Resolve the raw token first (so a file literally named "foo:42" still
+          // wins); only if that fails, retry after peeling a trailing :line[:col]
+          // suffix (e.g. "src/main.ts:42") and carry the line through so the file
+          // opens at that position.
+          let target = resolvePathTarget(candidate.value, this.app);
+          let targetLine: number | null = null;
+          if (!target) {
+            const { path, line } = splitLineSuffix(candidate.value);
+            if (path !== candidate.value) {
+              const stripped = resolvePathTarget(path, this.app);
+              if (stripped) {
+                target = stripped;
+                targetLine = line;
+              }
+            }
+          }
           if (!target) continue;
+          const resolved = target;
           links.push({
             range: {
               start: { x: candidate.start + 1, y: lineNumber },
@@ -657,18 +638,20 @@ export class TerminalTabManager {
             text: candidate.value,
             decorations: { pointerCursor: true, underline: true },
             activate: (_event: MouseEvent) => {
-              if (target.kind === "vault") {
-                const dest = this.app.metadataCache.getFirstLinkpathDest(target.linkpath, "");
+              if (resolved.kind === "vault") {
+                const dest = this.app.metadataCache.getFirstLinkpathDest(resolved.linkpath, "");
                 if (dest instanceof TFile) {
-                  void this.app.workspace.getLeaf("tab").openFile(dest);
+                  const viewState =
+                    targetLine != null ? { eState: { line: targetLine - 1 } } : undefined;
+                  void this.app.workspace.getLeaf("tab").openFile(dest, viewState);
                 } else {
-                  void this.app.workspace.openLinkText(target.linkpath, "", true);
+                  void this.app.workspace.openLinkText(resolved.linkpath, "", true);
                 }
               } else {
                 const { shell } = window.require("electron") as {
                   shell: { openPath: (p: string) => Promise<string> };
                 };
-                void shell.openPath(target.absPath);
+                void shell.openPath(resolved.absPath);
               }
             },
           });

--- a/src/terminal-tab-manager.ts
+++ b/src/terminal-tab-manager.ts
@@ -6,14 +6,19 @@ import { WebLinksAddon } from "@xterm/addon-web-links";
 import { SerializeAddon } from "@xterm/addon-serialize";
 import { SearchAddon } from "@xterm/addon-search";
 import type { IDisposable } from "@xterm/xterm";
-import { PtyManager } from "./pty-manager";
-import { findPathCandidates, splitLineSuffix } from "./path-links";
+import { PtyManager, getDefaultShell } from "./pty-manager";
 import { isObsidianDark } from "./themes";
 import { mixHex } from "./color-utils";
 import { findTabColor, DEFAULT_TINT_STRENGTH, MAX_TINT_STRENGTH } from "./tab-colors";
 import { ThemeRegistry } from "./theme-registry";
 import type { TerminalPluginSettings, NotificationSound } from "./settings";
 import { resolveShellPath } from "./settings";
+import {
+  findPathCandidates,
+  splitLineSuffix,
+  shellQuoteAlways,
+  buildExternalCommand,
+} from "./path-links";
 import type { BinaryManager } from "./binary-manager";
 import type { SavedTab } from "./session-state";
 import { WikiLinkAutocomplete, type AutocompleteEntry } from "./wikilink-autocomplete";
@@ -97,6 +102,12 @@ export interface CreateTabOpts {
   bufferSerial?: string;
   resumeCommand?: string;
   pinned?: boolean;
+  /**
+   * Skip auto-running the global `startupCommand` in this tab. Used when the caller
+   * runs its own command (e.g. opening an external file), so the two don't race
+   * onto the first prompt.
+   */
+  suppressGlobalStartup?: boolean;
 }
 
 /** Play a notification sound via the Web Audio API. */
@@ -216,12 +227,11 @@ function resolveSessionTheme(
 }
 
 function quotePath(rawPath: string, shellPath: string): string {
+  // Paths without spaces are passed as-is (dragged/pasted paths rarely need
+  // quoting); anything with a space is quoted for the target shell. The escaping
+  // and shell detection live in shellQuoteAlways so both call sites stay in sync.
   if (!rawPath.includes(" ")) return rawPath;
-  const lower = shellPath.toLowerCase();
-  if (lower.includes("bash") || lower.includes("zsh") || lower.includes("sh")) {
-    return `'${rawPath.replace(/'/g, "'\\''")}'`;
-  }
-  return `"${rawPath.replace(/"/g, '\\"')}"`;
+  return shellQuoteAlways(rawPath, shellPath);
 }
 
 /** Raster image extensions that TUIs such as Claude Code attach as vision input. */
@@ -526,6 +536,42 @@ export class TerminalTabManager {
     session.parserDisposables.push({ dispose: cleanup });
   }
 
+  /**
+   * Open a file that lives outside the vault. When `externalFileCommand` is set,
+   * run it in a fresh terminal tab (so TUI editors such as micro/vim/nano work,
+   * and files whose extension has no registered OS handler still open); otherwise
+   * hand the file to the OS default application via the Electron shell.
+   */
+  private openExternalFile(absPath: string, line: number | null): void {
+    const template = this.settings.externalFileCommand.trim();
+    if (!template) {
+      const { shell } = window.require("electron") as {
+        shell: { openPath: (p: string) => Promise<string> };
+      };
+      void shell.openPath(absPath);
+      return;
+    }
+    const path = window.require("path") as {
+      dirname(p: string): string;
+      basename(p: string): string;
+    };
+    // Quote against the shell that will ACTUALLY run — mirror PtyManager.spawn's
+    // resolution (explicit setting, else the auto-detected default). Quoting
+    // against the raw (often empty) setting would pick the wrong rules and could
+    // let a crafted filename inject shell code.
+    const shellPath = resolveShellPath(this.settings) || getDefaultShell();
+    const command = buildExternalCommand(template, absPath, line, shellPath);
+    // suppressGlobalStartup: this tab runs the file-open command itself; without
+    // this, createTab would ALSO fire the user's global startupCommand and the two
+    // would race onto the same prompt.
+    const session = this.createTab({
+      name: path.basename(absPath),
+      cwd: path.dirname(absPath),
+      suppressGlobalStartup: true,
+    });
+    this.setupStartupCommand(session, session.terminal, command);
+  }
+
   private buildXterm(
     containerEl: HTMLElement,
     opts?: CreateTabOpts,
@@ -648,10 +694,7 @@ export class TerminalTabManager {
                   void this.app.workspace.openLinkText(resolved.linkpath, "", true);
                 }
               } else {
-                const { shell } = window.require("electron") as {
-                  shell: { openPath: (p: string) => Promise<string> };
-                };
-                void shell.openPath(resolved.absPath);
+                this.openExternalFile(resolved.absPath, targetLine);
               }
             },
           });
@@ -1002,7 +1045,12 @@ export class TerminalTabManager {
     // Fresh new tabs (no persisted buffer, no saved resumeCommand) run the global
     // startup command. A separate path (not session.resumeCommand) keeps it out of
     // serialized workspace state so it never re-fires on restore.
-    if (!session.resumeCommand && !opts?.bufferSerial && this.settings.startupCommand) {
+    if (
+      !session.resumeCommand &&
+      !opts?.bufferSerial &&
+      !opts?.suppressGlobalStartup &&
+      this.settings.startupCommand
+    ) {
       this.setupStartupCommand(session, terminal, this.settings.startupCommand);
     }
 


### PR DESCRIPTION
## What does this PR do?

Adds an optional `externalFileCommand` setting so clicking a file **outside the vault** opens it in a new terminal tab with your editor of choice (e.g. `micro +%L -- %F`) instead of being handed to the OS default app.

> **Stacked on #93.** Until #93 merges this PR's diff also includes #93's commit; it will narrow to just this feature once #93 lands and the branch is rebased. Marked draft until then.

## Why

For a file outside the vault, `shell.openPath` relies on an OS file-type association — so an extension with no registered handler (`.astro`, etc.) opens nothing, and it can never jump to a line. Since this is a terminal plugin, running the file through a TUI editor in a new tab is a natural fit and keeps everything inside Obsidian.

## Details

- New `externalFileCommand` setting (default empty = current `shell.openPath` behavior). Placeholders: `%F` (shell-quoted absolute path), `%L` (1-based line, `1` when the link carried no line). When set, out-of-vault clicks open a new tab (cwd = the file's folder) running the command.
- **Shell-safe quoting** (`shellQuoteAlways`): resolves the shell the PTY will actually spawn (`resolveShellPath(settings) || getDefaultShell()`) and classifies it by binary **basename** — single-quoting for POSIX and PowerShell (also the safe default for an unknown/empty shell), double-quoting for cmd.exe. This prevents a crafted filename (`$(…)`, backticks, `$VAR`, `;`, `&`) from being interpreted by the shell. Covered by unit tests **plus a real `bash -c` round-trip** that asserts adversarial paths survive as a single literal argument.
- `quotePath` now delegates to `shellQuoteAlways` so the two quoting paths can't drift.
- `createTab` gains `suppressGlobalStartup` so the file-open command doesn't race the global `startupCommand` onto the first prompt.
- Warns (on blur) when a non-empty command omits `%F`.

## Checklist

- [x] `npm run build` passes locally
- [x] No existing features removed (external open falls back to the prior `shell.openPath` when the setting is empty)
- [x] `terminal-tab-manager.ts` was modified — changes are the external-open path, `quotePath` delegation, and a new `createTab` opt. Tab pinning, drag-and-drop, search, copy-on-select, and reordering are not touched. Verified via `tsc`, unit tests, and a production build; manual in-app QA of those subsystems not re-run.
- [x] No new dependencies

## Features removed (if any)

None.
