### PR TITLE
Focus terminal when Open terminal reveals an existing pane

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -242,6 +242,11 @@ export default class TerminalPlugin extends Plugin {
     const existing = this.app.workspace.getLeavesOfType(VIEW_TYPE_TERMINAL);
     if (existing.length > 0) {
       void this.app.workspace.revealLeaf(existing[0]);
+      // Reveal alone does not move keyboard focus into the terminal, so the cursor
+      // stays in the note editor. Make the leaf active with focus; TerminalView's
+      // active-leaf-change handler then focuses the xterm input. This mirrors the
+      // new-terminal path below, which focuses via setViewState({ active: true }).
+      this.app.workspace.setActiveLeaf(existing[0], { focus: true });
       return;
     }
 


### PR DESCRIPTION
## Problem

Running the **Open terminal** command (or clicking the ribbon icon) when a terminal pane already exists reveals the pane but does not move keyboard focus into it — the cursor stays in the note editor, so you have to click the terminal before typing. Because the terminal view is not an editor pane, none of Obsidian's built-in focus commands (`editor:focus-*`) target it either, so there's no user-side workaround.

## Cause

In `activateTerminal()` (`src/main.ts`), the early-return branch for an existing terminal only calls `revealLeaf`:

```ts
const existing = this.app.workspace.getLeavesOfType(VIEW_TYPE_TERMINAL);
if (existing.length > 0) {
  void this.app.workspace.revealLeaf(existing[0]);
  return;
}
```

`revealLeaf` shows the pane but does not make it the active leaf, so focus never moves. The new-terminal path further down *does* focus, because it calls `setViewState({ active: true, ... })`.

## Fix

Make the existing leaf active with focus after revealing it:

```ts
this.app.workspace.setActiveLeaf(existing[0], { focus: true });
```

`TerminalView` already registers an `active-leaf-change` handler that calls `tabManager.focusActive()` (which focuses the xterm input), so activating the leaf routes focus into the terminal. This mirrors the new-terminal path and keeps behavior consistent between first-open and re-open.

## Scope

One-line focus fix in the existing-terminal branch; no behavior change elsewhere. Verified with `npm run build` (tsc + esbuild) — compiles clean.